### PR TITLE
debug: Add min API that allows to get/set camera from dbg console.

### DIFF
--- a/static/erdblick/debugapi.js
+++ b/static/erdblick/debugapi.js
@@ -1,0 +1,55 @@
+"use strict";
+
+/**
+ * Debugging utility class designed for usage with the browser's debug console.
+ *
+ * Extends the actual application with debugging/dev functionality without
+ * contaminating the application's primary codebase or an addition of a dedicated
+ * GUI.
+ */
+export class ErdblickDebugApi {
+
+    /**
+     * Initialize a new ErdblickDebugApi instance.
+     * @param mapView Reference to a ErdblickView instance
+     */
+    constructor(mapView) {
+        this.mapView = mapView;
+    }
+
+    /**
+     * Update the camera position and orientation in the map view.
+     *
+     * @param cameraInfoStr A JSON-formatted string containing camera information.
+     */
+    setCamera(cameraInfoStr) {
+        const cameraInfo = JSON.parse(cameraInfoStr);
+        this.mapView.viewer.camera.setView({
+            destination: Cesium.Cartesian3.fromArray(cameraInfo.position),
+            orientation: {
+                heading: cameraInfo.orientation.heading,
+                pitch: cameraInfo.orientation.pitch,
+                roll: cameraInfo.orientation.roll
+            }
+        });
+    }
+
+    /**
+     * Retrieve the current camera position and orientation.
+     *
+     * @return A JSON-formatted string containing the current camera's position and orientation.
+     */
+    getCamera() {
+        const position = [
+            this.mapView.viewer.camera.position.x,
+            this.mapView.viewer.camera.position.y,
+            this.mapView.viewer.camera.position.z
+        ];
+        const orientation = {
+            heading: this.mapView.viewer.camera.heading,
+            pitch: this.mapView.viewer.camera.pitch,
+            roll: this.mapView.viewer.camera.roll
+        };
+        return JSON.stringify({ position, orientation });
+    }
+}

--- a/static/index.js
+++ b/static/index.js
@@ -1,6 +1,7 @@
 import { ErdblickView } from "./erdblick/view.js";
 import { ErdblickModel } from "./erdblick/model.js";
 import libErdblickCore from "./libs/core/erdblick-core.js";
+import { ErdblickDebugApi } from "./erdblick/debugapi.js";
 
 // --------------------------- Initialize Map Componesnt --------------------------
 console.log("Loading core library ...")
@@ -15,6 +16,11 @@ libErdblickCore().then(coreLib =>
     window.reloadStyle = () => {
         mapModel.reloadStyle();
     }
+
+    // Add debug API that can be easily called
+    // from browser's debug console
+    const debugApi = new ErdblickDebugApi(mapView);
+    window.ebDebug = debugApi;
 
     mapView.selectionTopic.subscribe(selectedFeatureWrapper => {
         if (!selectedFeatureWrapper) {


### PR DESCRIPTION
**Motivation and scope**: In the scope of testing scalability/performance of erdblick, I needed a way to always use the same location for my tests. I have thought about different ways how to achieve this with the current state of implementation. My conclusion was that it would be good if there'd be a component that allows me to add debug functionality easily but without polluting the regular code base, therfore I suggest to introduce the `ErdblickDebugApi` class.

**Testing**: To test this API, you can follow these steps using your browser's developer console:

1. **Get Current Camera Information**
    ```javascript
    const cameraInfo = window.ebDebug.getCamera();
    console.log(cameraInfo);
    ```

2. **Set Camera Position Using Previous Information**
    ```javascript
    window.ebDebug.setCamera(cameraInfo);
    ```
    
Simply copy the output from `getCamera()` and use it as input for `setCamera()`. This allows you to share and reuse camera positions across different sessions effortlessly.