### PR TITLE
Visualization performance and limit controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,16 @@ rule that matches it.
 > to edit and toggle multiple style sheets, the current alpha version loads
 > its style sheet from the hard-coded path [static/styles/demo-style.yaml](static/styles/demo-style.yaml).
 
-Each rule within the YAML `rules` array can have the following fields:
+Each rule within the YAML `rules` array can have the following fields. Any field marked with __`*`__ is optional:
 
-| Field      | Description                                                                                          | Type                                         | Optional? | Example Value                         |
-|------------|------------------------------------------------------------------------------------------------------|----------------------------------------------|-----------|---------------------------------------|
-| `geometry` | List of feature geometry type(s) the rule applies to.                                                | [`"point"`\|`"mesh"`\|`"line"`\|`"polygon"`] | No        | `["point", "mesh"]`                   |
-| `type`     | A regular expression to match against a feature type.                                                | String                                       | Yes       | `"Lane\|Boundary"`                    |
-| `filter`   | A [simfil](https://github.com/klebert-engineering/simfil) filter expression.                         | String                                       | Yes       | `properties.functionalRoadClass == 4` |
-| `color`    | A hexadecimal color code or [CSS color name](https://www.w3.org/wiki/CSS/Properties/color/keywords). | String                                       | Yes       | `"#FF5733"`, `red`                    |
-| `opacity`  | A float value between 0 and 1 indicating the opacity.                                                | Float                                        | Yes       | `0.8`                                 |
-| `width`    | Specifies the line width or point diameter (default in pixels).                                      | Float                                        | Yes       | `4.5`                                 |
+| Field          | Description                                                                                          | Type                                                       | Example Value       |
+|----------------|------------------------------------------------------------------------------------------------------|------------------------------------------------------------|---------------------|
+| `geometry`     | List of feature geometry type(s) the rule applies to.                                                | At least one of `"point"`,`"mesh"`, `"line"`, `"polygon"`. | `["point", "mesh"]` |
+| `type`__*__    | A regular expression to match against a feature type.                                                | String                                                     | `"Lane\|Boundary"`  |
+| `filter`__*__  | A [simfil](https://github.com/klebert-engineering/simfil) filter expression.                         | String                                                     | `*roadClass == 4`   |
+| `color`__*__   | A hexadecimal color code or [CSS color name](https://www.w3.org/wiki/CSS/Properties/color/keywords). | String                                                     | `"#FF5733"`, `red`  |
+| `opacity`__*__ | A float value between 0 and 1 indicating the opacity.                                                | Float                                                      | `0.8`               |
+| `width`__*__   | Specifies the line width or point diameter (default in pixels).                                      | Float                                                      | `4.5`               |
 
 **A brief example:**
 

--- a/libs/core/include/erdblick/cesium-interface/object.h
+++ b/libs/core/include/erdblick/cesium-interface/object.h
@@ -84,6 +84,11 @@ struct JsValue
     JsValue operator[](std::string const& propertyName);
 
     /**
+     * Set an object field or dictionary entry to a given value.
+     */
+    void set(std::string const& key, JsValue const& value);
+
+    /**
      * Push a value to a JS list.
      * For EMSCRIPTEN, it will use value_.push(o.value_).
      * For the mock version, it will append the push action to `methodCalls`.

--- a/libs/core/include/erdblick/stream.h
+++ b/libs/core/include/erdblick/stream.h
@@ -51,11 +51,18 @@ public:
      */
     void readFieldDictUpdate(SharedUint8Array const& buffer);
 
+    /**
+     * Set layer info which will be used if the external doesn't fit.
+     * Used for test data.
+     */
+    void setFallbackLayerInfo(std::shared_ptr<mapget::LayerInfo> info);
+
 private:
     std::map<std::string, mapget::DataSourceInfo> info_;
     std::unique_ptr<mapget::TileLayerStream::Reader> reader_;
     std::shared_ptr<mapget::TileLayerStream::CachedFieldsProvider> cachedFieldDicts_;
     std::function<void(mapget::TileFeatureLayer::Ptr)> tileParsedFun_;
+    std::shared_ptr<mapget::LayerInfo> fallbackLayerInfo_;
 };
 
 }

--- a/libs/core/include/erdblick/stream.h
+++ b/libs/core/include/erdblick/stream.h
@@ -2,6 +2,7 @@
 
 #include "mapget/model/stream.h"
 #include "buffer.h"
+#include "cesium-interface/object.h"
 
 namespace erdblick
 {
@@ -18,14 +19,15 @@ public:
     void setDataSourceInfo(SharedUint8Array const& dataSourceInfoJson);
 
     /**
-     * Serialize a TileFeatureLayer to a buffer.
-     */
-    void writeTileFeatureLayer(mapget::TileFeatureLayer::Ptr const& tile, SharedUint8Array& buffer);
-
-    /**
      * Parse a TileFeatureLayer from a buffer as returned by writeTileFeatureLayer.
      */
     mapget::TileFeatureLayer::Ptr readTileFeatureLayer(SharedUint8Array const& buffer);
+
+    /**
+     * Parse only the stringified MapTileKey and tile id from the tile layer blob.
+     * Returns two-element JS list, containing both.
+     */
+    NativeJsValue readTileLayerKeyAndTileId(SharedUint8Array const& buffer);
 
     /**
      * Reset the parser by removing any buffered unparsed stream chunks.
@@ -37,18 +39,12 @@ public:
      * This is used to tell the server whether additional field-id mapping updates
      * need to be sent.
      */
-    mapget::TileLayerStream::FieldOffsetMap fieldDictOffsets();
+    NativeJsValue getFieldDictOffsets();
 
     /**
-     * Stream-based parsing functionality: Set callback which is called
-     * as soon as a tile has been parsed.
+     * Add a chunk of streamed fields into this TileLayerParser.
      */
-    void onTileParsedFromStream(std::function<void(mapget::TileFeatureLayer::Ptr)>);
-
-    /**
-     * Add a chunk of streamed data into this TileLayerParser.
-     */
-    void parseFromStream(SharedUint8Array const& buffer);
+    void readFieldDictUpdate(SharedUint8Array const& buffer);
 
 private:
     std::map<std::string, mapget::DataSourceInfo> info_;

--- a/libs/core/include/erdblick/stream.h
+++ b/libs/core/include/erdblick/stream.h
@@ -9,6 +9,8 @@ namespace erdblick
 
 class TileLayerParser
 {
+    friend class TestDataProvider;
+
 public:
     explicit TileLayerParser();
 
@@ -53,7 +55,8 @@ public:
 
     /**
      * Set layer info which will be used if the external doesn't fit.
-     * Used for test data.
+     * Used for test data, which does not have layer info among the
+     * info fetched from the connected mapget service.
      */
     void setFallbackLayerInfo(std::shared_ptr<mapget::LayerInfo> info);
 
@@ -63,6 +66,9 @@ private:
     std::shared_ptr<mapget::TileLayerStream::CachedFieldsProvider> cachedFieldDicts_;
     std::function<void(mapget::TileFeatureLayer::Ptr)> tileParsedFun_;
     std::shared_ptr<mapget::LayerInfo> fallbackLayerInfo_;
+
+    std::shared_ptr<mapget::LayerInfo>
+    resolveMapLayerInfo(std::string const& mapId, std::string const& layerId);
 };
 
 }

--- a/libs/core/include/erdblick/stream.h
+++ b/libs/core/include/erdblick/stream.h
@@ -27,7 +27,12 @@ public:
      * Parse only the stringified MapTileKey and tile id from the tile layer blob.
      * Returns two-element JS list, containing both.
      */
-    NativeJsValue readTileLayerKeyAndTileId(SharedUint8Array const& buffer);
+    struct TileLayerMetadata {
+        std::string id;
+        uint64_t tileId;
+        int32_t numFeatures;
+    };
+    TileLayerMetadata readTileLayerMetadata(SharedUint8Array const& buffer);
 
     /**
      * Reset the parser by removing any buffered unparsed stream chunks.

--- a/libs/core/include/erdblick/testdataprovider.h
+++ b/libs/core/include/erdblick/testdataprovider.h
@@ -3,6 +3,7 @@
 #include "mapget/model/featurelayer.h"
 #include <iostream>
 #include "style.h"
+#include "stream.h"
 
 namespace erdblick
 {
@@ -10,7 +11,7 @@ namespace erdblick
 class TestDataProvider
 {
 public:
-    TestDataProvider()
+    TestDataProvider(TileLayerParser& tileLayerParser)
     {
         layerInfo_ = mapget::LayerInfo::fromJson(R"({
             "layerId": "WayLayer",
@@ -70,8 +71,11 @@ public:
             ]
         })"_json);
 
-        // Create empty shared autofilled field-name dictionary
-        fieldNames_ = std::make_shared<mapget::Fields>("TastyTomatoSaladNode");
+        // Get a field dictionary which the parser can later pick up again,
+        // and also inform the parser about the layer info used by features
+        // in the test data.
+        fieldNames_ = tileLayerParser.cachedFieldDicts_->operator()("TestDataNode");
+        tileLayerParser.setFallbackLayerInfo(layerInfo_);
     }
 
     std::shared_ptr<mapget::TileFeatureLayer> getTestLayer(double camX, double camY, uint16_t level)
@@ -87,8 +91,8 @@ public:
         // Create a basic TileFeatureLayer
         auto result = std::make_shared<mapget::TileFeatureLayer>(
             tileId,
-            "TastyTomatoSaladNode",
-            "GarlicChickenMap",
+            "TestDataNode",
+            "TestMap",
             layerInfo_,
             fieldNames_);
         result->setPrefix({{"areaId", "TheBestArea"}});

--- a/libs/core/include/erdblick/testdataprovider.h
+++ b/libs/core/include/erdblick/testdataprovider.h
@@ -115,7 +115,7 @@ public:
         };
 
         // Create 10 random Way features inside the bounding box defined by NE and SW
-        for (int i = 0; i < 10; i++) {
+        for (int i = 0; i < 2; i++) {
             std::cout << "Generated Way " << i << std::endl;
             // Create a feature with line geometry
             auto feature = result->newFeature("Way", {{"wayId", 42 + i}});
@@ -134,7 +134,7 @@ public:
         }
 
         // Create 10 random Sign features inside the bounding box defined by NE and SW
-        for (int i = 0; i < 10; i++) {
+        for (int i = 0; i < 2; i++) {
             std::cout << "Generated Sign " << i << std::endl;
 
             // Create a feature with polygon geometry

--- a/libs/core/src/bindings.cpp
+++ b/libs/core/src/bindings.cpp
@@ -99,7 +99,7 @@ std::string getTileFeatureLayerKey(std::string const& mapId, std::string const& 
 
 /** Create a test tile over New York. */
 std::shared_ptr<mapget::TileFeatureLayer> generateTestTile() {
-    return TestDataProvider().getTestLayer(-74.0060, 40.7128, 10);
+    return TestDataProvider().getTestLayer(-74.0060, 40.7128, 9);
 }
 
 /** Create a test style. */

--- a/libs/core/src/bindings.cpp
+++ b/libs/core/src/bindings.cpp
@@ -98,8 +98,12 @@ std::string getTileFeatureLayerKey(std::string const& mapId, std::string const& 
 }
 
 /** Create a test tile over New York. */
-std::shared_ptr<mapget::TileFeatureLayer> generateTestTile() {
-    return TestDataProvider().getTestLayer(-74.0060, 40.7128, 9);
+void generateTestTile(SharedUint8Array& output, TileLayerParser& parser) {
+    auto tile = TestDataProvider().getTestLayer(-74.0060, 40.7128, 9);
+    std::stringstream blob;
+    tile->write(blob);
+    output.writeToArray(blob.str());
+    parser.setFallbackLayerInfo(tile->layerInfo());
 }
 
 /** Create a test style. */

--- a/libs/core/src/bindings.cpp
+++ b/libs/core/src/bindings.cpp
@@ -192,6 +192,12 @@ EMSCRIPTEN_BINDINGS(erdblick)
         .constructor<FeatureLayerStyle const&, std::shared_ptr<mapget::TileFeatureLayer>>()
         .function("primitiveCollection", &FeatureLayerVisualization::primitiveCollection);
 
+    ////////// TileLayerMetadata
+    em::value_object<TileLayerParser::TileLayerMetadata>("Point")
+        .field("id", &TileLayerParser::TileLayerMetadata::id)
+        .field("tileId", &TileLayerParser::TileLayerMetadata::tileId)
+        .field("numFeatures", &TileLayerParser::TileLayerMetadata::numFeatures);
+
     ////////// TileLayerParser
     em::class_<TileLayerParser>("TileLayerParser")
         .constructor<>()
@@ -199,7 +205,7 @@ EMSCRIPTEN_BINDINGS(erdblick)
         .function("getFieldDictOffsets", &TileLayerParser::getFieldDictOffsets)
         .function("readFieldDictUpdate", &TileLayerParser::readFieldDictUpdate)
         .function("readTileFeatureLayer", &TileLayerParser::readTileFeatureLayer)
-        .function("readTileLayerKeyAndTileId", &TileLayerParser::readTileLayerKeyAndTileId)
+        .function("readTileLayerMetadata", &TileLayerParser::readTileLayerMetadata)
         .function("reset", &TileLayerParser::reset);
 
     ////////// Viewport TileID calculation

--- a/libs/core/src/bindings.cpp
+++ b/libs/core/src/bindings.cpp
@@ -196,25 +196,11 @@ EMSCRIPTEN_BINDINGS(erdblick)
     em::class_<TileLayerParser>("TileLayerParser")
         .constructor<>()
         .function("setDataSourceInfo", &TileLayerParser::setDataSourceInfo)
-        .function(
-            "onTileParsedFromStream",
-            std::function<void(TileLayerParser&, em::val)>(
-                [](TileLayerParser& self, em::val cb)
-                { self.onTileParsedFromStream([cb](auto&& tile) { cb(tile); }); }))
-        .function("parseFromStream", &TileLayerParser::parseFromStream)
-        .function("reset", &TileLayerParser::reset)
-        .function(
-            "fieldDictOffsets",
-            std::function<em::val(TileLayerParser&)>(
-                [](TileLayerParser& self)
-                {
-                    auto result = em::val::object();
-                    for (auto const& [nodeId, fieldId] : self.fieldDictOffsets())
-                        result.set(nodeId, fieldId);
-                    return result;
-                }))
+        .function("getFieldDictOffsets", &TileLayerParser::getFieldDictOffsets)
+        .function("readFieldDictUpdate", &TileLayerParser::readFieldDictUpdate)
         .function("readTileFeatureLayer", &TileLayerParser::readTileFeatureLayer)
-        .function("writeTileFeatureLayer", &TileLayerParser::writeTileFeatureLayer);
+        .function("readTileLayerKeyAndTileId", &TileLayerParser::readTileLayerKeyAndTileId)
+        .function("reset", &TileLayerParser::reset);
 
     ////////// Viewport TileID calculation
     em::function("getTileIds", &getTileIds);

--- a/libs/core/src/bindings.cpp
+++ b/libs/core/src/bindings.cpp
@@ -99,11 +99,10 @@ std::string getTileFeatureLayerKey(std::string const& mapId, std::string const& 
 
 /** Create a test tile over New York. */
 void generateTestTile(SharedUint8Array& output, TileLayerParser& parser) {
-    auto tile = TestDataProvider().getTestLayer(-74.0060, 40.7128, 9);
+    auto tile = TestDataProvider(parser).getTestLayer(-74.0060, 40.7128, 9);
     std::stringstream blob;
     tile->write(blob);
     output.writeToArray(blob.str());
-    parser.setFallbackLayerInfo(tile->layerInfo());
 }
 
 /** Create a test style. */

--- a/libs/core/src/cesium-interface/object.cpp
+++ b/libs/core/src/cesium-interface/object.cpp
@@ -91,6 +91,15 @@ void JsValue::push(const JsValue& o)
 #endif
 }
 
+void JsValue::set(const std::string& key, const JsValue& value)
+{
+#ifdef EMSCRIPTEN
+    value_.set(key, *value);
+#else
+    value_[key] = *value;
+#endif
+}
+
 CesiumClass::CesiumClass(const std::string& className)
     : className_(className)
 {

--- a/libs/core/src/stream.cpp
+++ b/libs/core/src/stream.cpp
@@ -69,7 +69,7 @@ mapget::TileFeatureLayer::Ptr TileLayerParser::readTileFeatureLayer(const Shared
     return result;
 }
 
-NativeJsValue TileLayerParser::readTileLayerKeyAndTileId(const SharedUint8Array& buffer)
+TileLayerParser::TileLayerMetadata TileLayerParser::readTileLayerMetadata(const SharedUint8Array& buffer)
 {
     std::stringstream inputStream;
     inputStream << buffer.toString();
@@ -80,10 +80,16 @@ NativeJsValue TileLayerParser::readTileLayerKeyAndTileId(const SharedUint8Array&
         inputStream,
         [this](auto&& mapId, auto&& layerId)
         { return info_[std::string(mapId)].getLayer(std::string(layerId)); });
-    auto resultTuple = JsValue::List({
-        JsValue(tileLayer.id().toString()),
-        JsValue(tileLayer.tileId().value_)});
-    return *resultTuple;
+    auto numFeatures = -1;
+    auto layerInfo = tileLayer.info();
+    if (layerInfo.is_object()) {
+        numFeatures = layerInfo.value<int32_t>("num-features", -1);
+    }
+    return {
+        tileLayer.id().toString(),
+        tileLayer.tileId().value_,
+        numFeatures
+    };
 }
 
 }

--- a/static/erdblick/debugapi.js
+++ b/static/erdblick/debugapi.js
@@ -1,5 +1,7 @@
 "use strict";
 
+import {uint8ArrayFromWasm} from "./wasm.js";
+
 /**
  * Debugging utility class designed for usage with the browser's debug console.
  *
@@ -59,8 +61,10 @@ export class ErdblickDebugApi {
      * Generate a test TileFeatureLayer, and show it.
      */
     showTestTile() {
-        let tile = this.coreLib.generateTestTile();
+        let tile = uint8ArrayFromWasm(this.coreLib, sharedArr => {
+            this.coreLib.generateTestTile(sharedArr, this.model.tileParser);
+        })
         let style = this.coreLib.generateTestStyle();
-        this.model.addTileLayer(tile, style, true);
+        this.model.addTileFeatureLayer(tile, style, true);
     }
 }

--- a/static/erdblick/features.js
+++ b/static/erdblick/features.js
@@ -36,34 +36,6 @@ export class FeatureTile
     }
 
     /**
-     * Convert this TileFeatureLayer to a Cesium Primitive which
-     * contains all visuals for this tile, given the style.
-     * Returns a promise which resolves to true, if there is a freshly baked
-     * Cesium Primitive under this.primitiveCollection, or false,
-     * if no output was generated because the tile is empty.
-     * @param {null} style The style that is used to make the conversion.
-     */
-    async render(style)
-    {
-        // Do not try to render if the underlying data is disposed.
-        if (this.disposed)
-            return false;
-
-        // Remove any previous render-result, as a new one is generated.
-        // TODO: Ensure that the View also takes note of the removed PrimitiveCollection.
-        //  This will become apparent once interactive re-styling is a prime use-case.
-        this.disposeRenderResult();
-
-        this.peek(tileFeatureLayer => {
-            let visualization = new this.coreLib.FeatureLayerVisualization(style, tileFeatureLayer);
-            this.primitiveCollection = visualization.primitiveCollection();
-        });
-
-        // The primitive collection will be null if there were no features to render.
-        return this.primitiveCollection !== null && this.primitiveCollection !== undefined;
-    }
-
-    /**
      * Deserialize the wrapped TileFeatureLayer, run a callback, then
      * delete the deserialized WASM representation.
      * @returns The value returned by the callback.
@@ -82,23 +54,10 @@ export class FeatureTile
     }
 
     /**
-     * Remove all data associated with a previous call to this.render().
+     * Mark this tile as "not available anymore".
      */
-    disposeRenderResult()
+    destroy()
     {
-        if (!this.primitiveCollection)
-            return;
-        if (!this.primitiveCollection.isDestroyed())
-            this.primitiveCollection.destroy();
-        this.primitiveCollection = null;
-    }
-
-    /**
-     * Clean up all data associated with this FeatureTile instance.
-     */
-    dispose()
-    {
-        this.disposeRenderResult();
         this.disposed = true;
     }
 }

--- a/static/erdblick/features.js
+++ b/static/erdblick/features.js
@@ -3,9 +3,7 @@
 import {uint8ArrayToWasm} from "./wasm.js";
 
 /**
- * Bundle of a WASM TileFeatureLayer and a rendered representation
- * in the form of a Cesium PrimitiveCollection.
- *
+ * JS interface of a WASM TileFeatureLayer.
  * The WASM TileFeatureLayer object is stored as a blob when not needed,
  * to keep the memory usage within reasonable limits. To use the wrapped
  * WASM TileFeatureLayer, use the peek()-function.
@@ -23,11 +21,12 @@ export class FeatureTile
      */
     constructor(coreLib, parser, tileFeatureLayerBlob, preventCulling)
     {
-        let mapTileKeyAndTileId = uint8ArrayToWasm(coreLib, wasmBlob => {
-            return parser.readTileLayerKeyAndTileId(wasmBlob);
+        let mapTileMetadata = uint8ArrayToWasm(coreLib, wasmBlob => {
+            return parser.readTileLayerMetadata(wasmBlob);
         }, tileFeatureLayerBlob);
-        this.id = mapTileKeyAndTileId[0];
-        this.tileId = mapTileKeyAndTileId[1];
+        this.id = mapTileMetadata.id;
+        this.tileId = mapTileMetadata.tileId;
+        this.numFeatures = mapTileMetadata.numFeatures;
         this.coreLib = coreLib;
         this.parser = parser;
         this.preventCulling = preventCulling;

--- a/static/erdblick/fetch.js
+++ b/static/erdblick/fetch.js
@@ -239,8 +239,8 @@ export class Fetch
      * Log an error if it does not relate to an intentional abort-call.
      */
     handleError(e) {
-        if (e !== "User abort.") {
-            console.error(e);
-        }
+        if (e === "User abort." || (e && e.name === "AbortError"))
+            return;
+        console.error(e);
     }
 }

--- a/static/erdblick/model.js
+++ b/static/erdblick/model.js
@@ -22,7 +22,7 @@ const tileUrl = "/tiles";
  */
 export class ErdblickModel
 {
-    static MAX_NUM_TILES_TO_LOAD = 32768*2;
+    static MAX_NUM_TILES_TO_LOAD = 2048;
     static MAX_NUM_TILES_TO_VISUALIZE = 512;
 
     constructor(coreLibrary)
@@ -46,6 +46,8 @@ export class ErdblickModel
         this.currentHighDetailTileIds = new Set();
         this.tileStreamParsingQueue = [];
         this.tileVisualizationQueue = [];
+        this.maxLoadTiles = ErdblickModel.MAX_NUM_TILES_TO_LOAD;
+        this.maxVisuTiles = ErdblickModel.MAX_NUM_TILES_TO_VISUALIZE;
 
         // Instantiate the TileLayerParser, and set its callback
         // for when a new tile is received.
@@ -170,9 +172,9 @@ export class ErdblickModel
     update()
     {
         // Get the tile IDs for the current viewport.
-        const allViewportTileIds = this.coreLib.getTileIds(this.currentViewport, 13, ErdblickModel.MAX_NUM_TILES_TO_LOAD);
+        const allViewportTileIds = this.coreLib.getTileIds(this.currentViewport, 13, this.maxLoadTiles);
         this.currentVisibleTileIds = new Set(allViewportTileIds);
-        this.currentHighDetailTileIds = new Set(allViewportTileIds.slice(0, ErdblickModel.MAX_NUM_TILES_TO_VISUALIZE))
+        this.currentHighDetailTileIds = new Set(allViewportTileIds.slice(0, this.maxVisuTiles))
 
         // Abort previous fetch operation.
         if (this.currentFetch) {

--- a/static/erdblick/view.js
+++ b/static/erdblick/view.js
@@ -238,7 +238,7 @@ export class ErdblickView
             height: sizeLat + expandLat*2,
             camPosLon: centerLon,
             camPosLat: centerLat,
-            orientation: this.viewer.camera.heading,
+            orientation: -this.viewer.camera.heading + Math.PI * .5,
         });
     }
 }

--- a/static/erdblick/view.js
+++ b/static/erdblick/view.js
@@ -210,6 +210,10 @@ export class ErdblickView
         }
 
         let rectangle = this.viewer.camera.computeViewRectangle();
+        if (!rectangle) {
+            // This might happen when looking into space.
+            return;
+        }
 
         let west = Cesium.Math.toDegrees(rectangle.west);
         let south = Cesium.Math.toDegrees(rectangle.south);

--- a/static/erdblick/visualization.js
+++ b/static/erdblick/visualization.js
@@ -1,0 +1,108 @@
+import {FeatureTile} from "./features.js";
+
+/** Bundle of a FeatureTile and a rendered */
+export class TileVisualization
+{
+    /**
+     * Create a tile visualization.
+     * @param tile {FeatureTile} The tile to visualize.
+     * @param style The style to use for visualization.
+     * @param highDetail The level of detail to use. Currently,
+     *  a low-detail representation is indicated by `false`, and
+     *  will result in a dot representation. A high-detail representation
+     *  based on the style can be triggered using `true`.
+     */
+    constructor(tile, style, highDetail) {
+        this.tile = tile;
+        this.style = style;
+        this.isHighDetail = highDetail;
+
+        this.entity = null;  // Low-detail or empty -> Cesium point entity.
+        this.primitiveCollection = null; // High-detail -> PrimitiveCollection.
+
+        this.hasHighDetailVisualization = false; // Currently holding hd?
+        this.hasLowDetailVisualization = false; // Currently holding ld?
+    }
+
+    /**
+     * Actually create the visualization.
+     * @param viewer {Cesium.Viewer} The viewer to add the rendered entity to.
+     */
+    render(viewer) {
+        // Remove any previous render-result, as a new one is generated.
+        this.destroy(viewer);
+
+        // Do not try to render if the underlying data is disposed.
+        if (this.tile.disposed)
+            return false;
+
+        // Create potential high-detail visualization
+        if (this.isHighDetailAndNotEmpty()) {
+            this.tile.peek(tileFeatureLayer => {
+                let visualization = new this.tile.coreLib.FeatureLayerVisualization(this.style, tileFeatureLayer);
+                this.primitiveCollection = visualization.primitiveCollection();
+            });
+            if (this.primitiveCollection)
+                viewer.scene.primitives.add(this.primitiveCollection);
+            this.hasHighDetailVisualization = true;
+            return;
+        }
+
+        // Else: Low-detail dot representation
+        let position = this.tile.coreLib.getTilePosition(this.tile.tileId);
+        let color = (this.tile.numFeatures <= 0) ? Cesium.Color.ALICEBLUE.withAlpha(.5) : Cesium.Color.LAWNGREEN.withAlpha(.5);
+        this.entity = viewer.entities.add({
+            position: Cesium.Cartesian3.fromDegrees(position.x, position.y),
+            point: {
+                pixelSize: 5,
+                color: color
+            }
+        });
+        this.hasLowDetailVisualization = true;
+    }
+
+    /**
+     * Destroy any current visualization.
+     * @param viewer {Cesium.Viewer} The viewer to remove the rendered entity from.
+     */
+    destroy(viewer) {
+        if (this.primitiveCollection) {
+            viewer.scene.primitives.remove(this.primitiveCollection);
+            if (!this.primitiveCollection.isDestroyed())
+                this.primitiveCollection.destroy();
+            this.primitiveCollection = null;
+        }
+        if (this.entity) {
+            viewer.entities.remove(this.entity);
+            this.entity = null;
+        }
+        this.hasHighDetailVisualization = false;
+        this.hasLowDetailVisualization = false;
+    }
+
+    /**
+     * Iterate over all Cesium primitives of this visualization.
+     */
+    forEachPrimitive(callback) {
+        if (this.primitiveCollection)
+            for (let i = 0; i < this.primitiveCollection.length; ++i)
+                callback(this.primitiveCollection.get(i));
+    }
+
+    /**
+     * Check if the visualization is high-detail, and the
+     * underlying data is not empty.
+     */
+    isHighDetailAndNotEmpty() {
+        return this.isHighDetail && (this.tile.numFeatures > 0 || this.tile.preventCulling);
+    }
+
+    /**
+     * Check if this visualization needs re-rendering, based on
+     * whether the isHighDetail flag changed.
+     */
+    isDirty() {
+        return (
+            (this.isHighDetailAndNotEmpty() && !this.hasHighDetailVisualization) || (!this.isHighDetailAndNotEmpty() && !this.hasLowDetailVisualization));
+    }
+}

--- a/static/index.css
+++ b/static/index.css
@@ -90,6 +90,10 @@ body {
     left: 10px;
 }
 
+#info > #controls {
+    display: none;
+}
+
 #info > #maps {
     display: none;
 }
@@ -97,6 +101,10 @@ body {
 #info > #maps > div {
     margin-top: 0.5em;
     margin-bottom: 0;
+}
+
+#info.expanded > #controls {
+    display: block;
 }
 
 #info.expanded > #maps {

--- a/static/index.html
+++ b/static/index.html
@@ -7,9 +7,7 @@
     <!-- Non-Module 3rd-party sources -->
     <script src="./deps/jquery-3.2.1-min.js"></script>
     <script src="https://unpkg.com/rxjs@^7/dist/bundles/rxjs.umd.min.js"></script>
-    <script src="https://cesium.com/downloads/cesiumjs/releases/1.108/Build/Cesium/Cesium.js"></script>
-    <!-- Enable for debugging with CesiumUnminified folder from Cesium Release zip. -->
-    <!-- <script src="./deps/CesiumUnminified/Cesium.js"></script> -->
+    <script src="https://cesium.com/downloads/cesiumjs/releases/1.110/Build/Cesium/Cesium.js"></script>
 
     <!-- Erdblick WASM library -->
     <script type="module" src="./libs/core/erdblick-core.js"></script>
@@ -25,7 +23,7 @@
 
     <!-- Style sheets -->
     <link rel="stylesheet" href="./index.css">
-    <link href="https://cesium.com/downloads/cesiumjs/releases/1.108/Build/Cesium/Widgets/widgets.css" rel="stylesheet">
+    <link href="https://cesium.com/downloads/cesiumjs/releases/1.110/Build/Cesium/Widgets/widgets.css" rel="stylesheet">
 </head>
 <body>
 

--- a/static/index.html
+++ b/static/index.html
@@ -33,6 +33,18 @@
     <span class="toggle-indicator"></span>
     erdblick v0.3.0 //
     <button onclick="reloadStyle()">Reload Style</button><br>
+    <div id="controls">
+        <!-- Label and input field for MAX_NUM_TILES_TO_LOAD -->
+        <label for="tilesToLoadInput">Max Tiles to Load:</label>
+        <input type="number" id="tilesToLoadInput" placeholder="Enter max tiles to load" min="1"><br>
+
+        <!-- Label and input field for MAX_NUM_TILES_TO_VISUALIZE -->
+        <label for="tilesToVisualizeInput">Max Tiles to Visualize:</label>
+        <input type="number" id="tilesToVisualizeInput" placeholder="Enter max tiles to visualize" min="1"><br>
+
+        <!-- Apply button -->
+        <button onclick="applyTileLimits()">Apply Tile Limits</button>
+    </div>
     <div id="maps"></div>
 </div>
 

--- a/static/index.js
+++ b/static/index.js
@@ -17,6 +17,29 @@ libErdblickCore().then(coreLib =>
         mapModel.reloadStyle();
     }
 
+    document.getElementById("tilesToLoadInput").value = mapModel.maxLoadTiles;
+    document.getElementById("tilesToVisualizeInput").value = mapModel.maxVisuTiles;
+    // Prevent event propagation for input fields
+    $("#tilesToLoadInput, #tilesToVisualizeInput").on("click", function(event) {
+        event.stopPropagation();
+    });
+    window.applyTileLimits = () => {
+        const tilesToLoad = parseInt(document.getElementById("tilesToLoadInput").value);
+        const tilesToVisualize = parseInt(document.getElementById("tilesToVisualizeInput").value);
+
+        if (isNaN(tilesToLoad) || isNaN(tilesToVisualize)) {
+            alert("Please enter valid tile limits!");
+            return;
+        }
+
+        mapModel.maxLoadTiles = tilesToLoad;
+        mapModel.maxVisuTiles = tilesToVisualize;
+        mapModel.update();
+
+        console.log(`Max tiles to load set to ${tilesToLoad}`);
+        console.log(`Max tiles to visualize set to ${tilesToVisualize}`);
+    }
+
     // Add debug API that can be easily called
     // from browser's debug console
     const debugApi = new ErdblickDebugApi(mapView);

--- a/static/styles/demo-style.yaml
+++ b/static/styles/demo-style.yaml
@@ -1,6 +1,7 @@
 name: DemoStyle
 version: 1.0
 rules:
-  - geometry: ["line"]
-    color: "#ff0000"
+  - geometry: ["line", "mesh", "polygon"]
+    color: red
     opacity: 1.0
+    width: 2.0

--- a/test/test-visualization.cpp
+++ b/test/test-visualization.cpp
@@ -2,6 +2,7 @@
 
 #include "erdblick/testdataprovider.h"
 #include "erdblick/visualization.h"
+#include "erdblick/stream.h"
 
 #include <iostream>
 
@@ -9,7 +10,8 @@ using namespace erdblick;
 
 TEST_CASE("FeatureLayerVisualization", "[erdblick.renderer]")
 {
-    auto testLayer = TestDataProvider().getTestLayer(42., 11., 13);
+    TileLayerParser tlp;
+    auto testLayer = TestDataProvider(tlp).getTestLayer(42., 11., 13);
     FeatureLayerVisualization visualization(TestDataProvider::style(), testLayer);
     auto result = visualization.primitiveCollection();
     std::cout << result << std::endl;


### PR DESCRIPTION
Fixes #23 
Fixes #24 
Fixes #32 
Fixes #31 
Fixes #51 
Fixes #29 

**The main changes:**

* The `FeatureTile` class now only ever parses the tile when HD visu is required, and holds on to the blob.
* Dynamic HD/low-res Visualization is taken over by the `TileVisualization` class, for which updates are processed in a separate queue.
* The features in the test tile can now be picked.
* Fixed a Cesium crash when staring into space.
* Fixed orientation calculation for view-direction-based loading.