### PR TITLE
minor changes to fix MSVC build

### DIFF
--- a/libs/core/include/erdblick/aabb.h
+++ b/libs/core/include/erdblick/aabb.h
@@ -5,6 +5,7 @@
 
 #include <iostream>
 #include <list>
+#include <functional>
 
 namespace erdblick
 {

--- a/libs/core/include/erdblick/buffer.h
+++ b/libs/core/include/erdblick/buffer.h
@@ -15,7 +15,7 @@ public:
     explicit SharedUint8Array(uint32_t size);
     explicit SharedUint8Array(std::string const& data);
     [[nodiscard]] uint32_t getSize() const;
-    __UINT64_TYPE__ getPointer();
+    uintptr_t getPointer();
 
     void writeToArray(const char* start, const char* end);
     void writeToArray(std::string const& content);

--- a/libs/core/src/aabb.cpp
+++ b/libs/core/src/aabb.cpp
@@ -1,6 +1,15 @@
 #include "aabb.h"
-
+#define _USE_MATH_DEFINES
+#include <cmath>
 #include "glm/ext.hpp"
+
+
+// For non-GNU compilers (e.g. MSVC).
+// Consider switching to std::numbers::pi once C++20 support
+// is available.
+#ifndef M_PI_2
+#define M_PI_2 1.57079632679489661923  /* π/2 */
+#endif
 
 namespace erdblick
 {

--- a/libs/core/src/buffer.cpp
+++ b/libs/core/src/buffer.cpp
@@ -20,9 +20,9 @@ SharedUint8Array::SharedUint8Array(const std::string& data)
     array_.assign(data.begin(), data.end());
 }
 
-__UINT64_TYPE__ SharedUint8Array::getPointer()
+uintptr_t SharedUint8Array::getPointer()
 {
-    return reinterpret_cast<__UINT64_TYPE__>(array_.data());
+    return reinterpret_cast<uintptr_t>(array_.data());
 }
 
 void SharedUint8Array::writeToArray(const char* start, const char* end)


### PR DESCRIPTION
I am not 100% sure about the pointer casting code. Casting a pointer to an `uint64` is not portable. Is there a reason why the pointer cast is made to `uint64`?