### PR TITLE
Support usage of erblick as cmake subdir project.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ FetchContent_MakeAvailable(yaml-cpp)
 add_subdirectory(libs/core)
 
 add_custom_target(static-web-files ALL
-    COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_SOURCE_DIR}/static" "${CMAKE_BINARY_DIR}")
+    COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/static" "${CMAKE_CURRENT_BINARY_DIR}")
 
 if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")
   add_subdirectory(test)


### PR DESCRIPTION
Currently erdblick's CMake cfg expects that it is the top-level one, but when re-using it in a different project it can be useful to just add it as a subdir. This PR introduces the support for this use case.

- [ ] Not sure yet, if my changes are enough - to be discussed.