### PR TITLE
Add style option to clamp features to ground

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Each rule within the YAML `rules` array can have the following fields. Any field
 | `color`__*__   | A hexadecimal color code or [CSS color name](https://www.w3.org/wiki/CSS/Properties/color/keywords). | String                                                     | `"#FF5733"`, `red`  |
 | `opacity`__*__ | A float value between 0 and 1 indicating the opacity.                                                | Float                                                      | `0.8`               |
 | `width`__*__   | Specifies the line width or point diameter (default in pixels).                                      | Float                                                      | `4.5`               |
+| `flat`__*__    | Clamps the feature to the ground (meshes not supported)                                              | Boolean                                                    | `true`, `false`     |
 
 **A brief example:**
 

--- a/libs/core/include/erdblick/cesium-interface/cesium.h
+++ b/libs/core/include/erdblick/cesium-interface/cesium.h
@@ -26,6 +26,9 @@ struct CesiumLib
     CesiumClass Primitive;
     CesiumClass PrimitiveCollection;
     CesiumClass PrimitiveType;
+    CesiumClass GroundPolylineGeometry;
+    CesiumClass GroundPolylinePrimitive;
+    CesiumClass GroundPrimitive;
 
     [[nodiscard]] JsValue MaterialFromType(std::string const& type, JsValue const& options);
 

--- a/libs/core/include/erdblick/cesium-interface/primitive.h
+++ b/libs/core/include/erdblick/cesium-interface/primitive.h
@@ -21,7 +21,7 @@ struct CesiumPrimitive
      * Create a primitive which uses the PolylineColorAppearance.
      * See https://cesium.com/learn/cesiumjs/ref-doc/PolylineColorAppearance.html
      */
-    static CesiumPrimitive withPolylineColorAppearance();
+    static CesiumPrimitive withPolylineColorAppearance(bool clampToGround = false);
 
     /**
      * Create a primitive which uses the PerInstanceColorAppearance.
@@ -32,7 +32,7 @@ struct CesiumPrimitive
      * smoothly shaded triangle meshes by calling Cesium.GeometryPipeline.computeNormal
      * and Cesium.GeometryPipeline.compressVertices on the mesh geometry.
      */
-    static CesiumPrimitive withPerInstanceColorAppearance(bool flatAndSynchronous = false);
+    static CesiumPrimitive withPerInstanceColorAppearance(bool flatAndSynchronous = false, bool clampToGround = false);
 
     /**
      * Add a 3D polyline to the primitive. The provided vertices
@@ -90,6 +90,10 @@ private:
 
     /** Flag which enables the direct triangle display required for addTriangles. */
     bool flatAndSynchronous_ = false;
+
+    /** Flags to clamp geometries to ground. */
+    bool clampToGround_ = false;
+    bool polyLinePrimitive_ = false;
 };
 
 }

--- a/libs/core/include/erdblick/rule.h
+++ b/libs/core/include/erdblick/rule.h
@@ -20,6 +20,7 @@ public:
     [[nodiscard]] bool supports(mapget::Geometry::GeomType const& g) const;
     [[nodiscard]] glm::fvec4 const& color() const;
     [[nodiscard]] float width() const;
+    [[nodiscard]] bool flat() const;
 
 private:
     static inline uint32_t geomTypeBit(mapget::Geometry::GeomType const& g) {
@@ -31,6 +32,7 @@ private:
     std::string filter_;
     glm::fvec4 color_{.0, .0, .0, 1.};
     float width_ = 1.;
+    bool flat_ = false;
 };
 
 }

--- a/libs/core/include/erdblick/testdataprovider.h
+++ b/libs/core/include/erdblick/testdataprovider.h
@@ -217,6 +217,14 @@ public:
             width: 3.0
 
           - geometry:
+              - line
+            type: "Way"
+            filter: "properties.wayType == 'Vehicle'"
+            color: "#17e38e"
+            width: 3.0
+            flat: true
+
+          - geometry:
               - polygon
             type: "Sign"
             filter: "properties.signType == 'Stop'"
@@ -245,6 +253,12 @@ public:
             type: "Sign"
             filter: "properties.signType == 'Speed Limit'"
             color: "#2c3e50" # Dark color for Speed Limit Sign
+
+          - geometry:
+              - polygon
+            type: "Sign"
+            color: "#e342f5" # Dark color for Speed Limit Sign
+            flat: true
 
           - geometry:
               - mesh

--- a/libs/core/include/erdblick/visualization.h
+++ b/libs/core/include/erdblick/visualization.h
@@ -54,6 +54,9 @@ private:
     CesiumPrimitive coloredLines_;
     CesiumPrimitive coloredNontrivialMeshes_;
     CesiumPrimitive coloredTrivialMeshes_;
+    CesiumPrimitive coloredGroundLines_;
+    CesiumPrimitive coloredGroundMeshes_;
+
 };
 
 }  // namespace erdblick

--- a/libs/core/src/cesium-interface/cesium.cpp
+++ b/libs/core/src/cesium-interface/cesium.cpp
@@ -21,7 +21,10 @@ CesiumLib::CesiumLib() :
     PolylineMaterialAppearance("PolylineMaterialAppearance"),
     Primitive("Primitive"),
     PrimitiveCollection("PrimitiveCollection"),
-    PrimitiveType("PrimitiveType")
+    PrimitiveType("PrimitiveType"),
+    GroundPolylineGeometry("GroundPolylineGeometry"),
+    GroundPolylinePrimitive("GroundPolylinePrimitive"),
+    GroundPrimitive("GroundPrimitive")
 {
 }
 

--- a/libs/core/src/rule.cpp
+++ b/libs/core/src/rule.cpp
@@ -55,6 +55,10 @@ FeatureStyleRule::FeatureStyleRule(YAML::Node const& yaml)
         // Parse a line width, defaults to pixels
         width_ = yaml["width"].as<float>();
     }
+    if (yaml["flat"].IsDefined()) {
+        // Parse option to clamp feature to ground (ignoring height), defaults to false
+        flat_ = yaml["flat"].as<bool>();
+    }
 }
 
 bool FeatureStyleRule::match(mapget::Feature& feature) const
@@ -88,6 +92,11 @@ glm::fvec4 const& FeatureStyleRule::color() const
 float FeatureStyleRule::width() const
 {
     return width_;
+}
+
+bool FeatureStyleRule::flat() const
+{
+    return flat_;
 }
 
 }

--- a/static/styles/demo-style.yaml
+++ b/static/styles/demo-style.yaml
@@ -5,3 +5,4 @@ rules:
     color: red
     opacity: 1.0
     width: 2.0
+    flat: false


### PR DESCRIPTION
Add `flat`  as style option. If used geometries are created/handles slightly differently:
-  `PolylineGeometry` willl be created as `GroundPolylineGeometry` and added to a `GroundPolylinePrimitive`
- `PolygonGeometry` will be added to a `GroundPrimitive` instead of `Primitive` (no need to change geometry type)

**Testing**
Find some map with lanes hovering above background (e.g. island6) and toggle between style `flat: true` and `flat: false`. When true all lanes should be at the the same height as ground.