### PR TITLE
Use Conan 2

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -18,16 +18,6 @@ jobs:
         run: |
           sudo apt update && sudo apt install ninja-build
 
-      - name: Use Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '21.x'
-          cache: "npm"
-          cache-dependency-path: package-lock.json
-
-      - name: Install npm dependencies
-        run: npm -g install --force --include=dev
-
       - name: Install Conan
         run: |
           pip install conan

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -29,7 +29,7 @@ jobs:
           cd $(mktemp -d)
           git clone "https://github.com/ndsev/mapget.git" -b use-conan
           cd mapget
-          conan create . -s compiler.cppstd=20 -b missing \
+          conan create . -s compiler.cppstd=20 -s build_type=Release -b missing \
             -pr:b default -pr:h "$GITHUB_WORKSPACE/conan-profiles/emscripten.profile" \
             -o with_httplib=False \
             -o with_service=False \

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -14,15 +14,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Use Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '21.x'
-          cache: "npm"
-          cache-dependency-path: package-lock.json
-
-      - name: Install npm dependencies
-        run: npm -g install --force --include=dev
+      - name: Install Ninja
+        run: |
+          sudo apt update && sudo apt install ninja-build
+      - name: Install Conan
+        run: |
+          pip install conan
+          conan profile detect
 
       - name: Build demo with Emscripten
         run: |

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -18,17 +18,32 @@ jobs:
         run: |
           sudo apt update && sudo apt install ninja-build
 
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '21.x'
+          cache: "npm"
+          cache-dependency-path: package-lock.json
+
+      - name: Install npm dependencies
+        run: npm -g install --force --include=dev
+
       - name: Install Conan
         run: |
           pip install conan
           conan profile detect
+          conan --version
 
       - name: Install mapget (git+conan)
         run: |
           cd $(mktemp -d)
-          git clone "https://github.com/ndsev/mapget.git" -b conan-pkg
+          git clone "https://github.com/ndsev/mapget.git" -b use-conan
           cd mapget
-          conan create . -o with_service=False -s compiler.cppstd=20 -b missing
+          conan create . -s compiler.cppstd=20 -b missing \
+            -pr:b default -pr:h "$GITHUB_WORKSPACE/conan-profiles/emscripten.profile" \
+            -o with_httplib=False \
+            -o with_service=False \
+            -o with_wheel=False
 
       - name: Build demo with Emscripten
         run: |

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -17,10 +17,18 @@ jobs:
       - name: Install Ninja
         run: |
           sudo apt update && sudo apt install ninja-build
+
       - name: Install Conan
         run: |
           pip install conan
           conan profile detect
+
+      - name: Install mapget (git+conan)
+        run: |
+          cd $(mktemp -d)
+          git clone "https://github.com/ndsev/mapget.git" -b conan-pkg
+          cd mapget
+          conan create . -o with_service=False -s compiler.cppstd=20 -b missing
 
       - name: Build demo with Emscripten
         run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,11 +36,13 @@ FetchContent_Declare(
   GIT_SHALLOW ON)
 FetchContent_MakeAvailable(cesiumnative)
 
-FetchContent_Declare(mapget
-  GIT_REPOSITORY "https://github.com/Klebert-Engineering/mapget"
-  GIT_TAG        "main"
-  GIT_SHALLOW    ON)
-FetchContent_MakeAvailable(mapget)
+if (NOT TARGET mapget)
+  FetchContent_Declare(mapget
+    GIT_REPOSITORY "https://github.com/Klebert-Engineering/mapget"
+    GIT_TAG        "main"
+    GIT_SHALLOW    ON)
+  FetchContent_MakeAvailable(mapget)
+endif()
 
 # Erdblick Core Library
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,4 @@
 cmake_minimum_required(VERSION 3.24)
-project(erdblick)
-
 include(FetchContent)
 
 set(CMAKE_CXX_STANDARD 20)
@@ -18,11 +16,8 @@ endif()
 
 message("Building for ${CMAKE_SYSTEM_NAME}.")
 
-FetchContent_Declare(glm
-    GIT_REPOSITORY "https://github.com/g-truc/glm.git"
-    GIT_TAG        "0.9.9.8"
-    GIT_SHALLOW    ON)
-FetchContent_MakeAvailable(glm)
+find_package(glm REQUIRED)
+find_package(yaml-cpp REQUIRED)
 
 FetchContent_Declare(mapget
   GIT_REPOSITORY "https://github.com/Klebert-Engineering/mapget"
@@ -41,11 +36,11 @@ FetchContent_Declare(
   GIT_SHALLOW ON)
 FetchContent_MakeAvailable(cesiumnative)
 
-FetchContent_Declare(yaml-cpp
-  GIT_REPOSITORY "https://github.com/jbeder/yaml-cpp.git"
-  GIT_TAG        "yaml-cpp-0.7.0"
+FetchContent_Declare(mapget
+  GIT_REPOSITORY "https://github.com/Klebert-Engineering/mapget"
+  GIT_TAG        "main"
   GIT_SHALLOW    ON)
-FetchContent_MakeAvailable(yaml-cpp)
+FetchContent_MakeAvailable(mapget)
 
 # Erdblick Core Library
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,9 @@
 cmake_minimum_required(VERSION 3.24)
-project(erdblick)
+
+project(erdblick CXX)
 
 set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Treat warnings as errors, with some exceptions for Cesium.
 set (ERDBLICK_CXX_FLAGS
@@ -13,9 +15,9 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 endif()
 
 # External dependencies.
-find_package(mapget   REQUIRED COMPONENTS model)
-find_package(glm      REQUIRED)
-find_package(yaml-cpp REQUIRED)
+find_package(mapget   CONFIG REQUIRED COMPONENTS model)
+find_package(glm      CONFIG REQUIRED)
+find_package(yaml-cpp CONFIG REQUIRED)
 
 # Cesium
 include(cmake/cesium.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.24)
-include(FetchContent)
+project(erdblick)
 
 set(CMAKE_CXX_STANDARD 20)
 
@@ -13,46 +13,14 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
 endif()
 
 # External dependencies.
-
-message("Building for ${CMAKE_SYSTEM_NAME}.")
-
-find_package(glm REQUIRED)
+find_package(mapget   REQUIRED COMPONENTS model)
+find_package(glm      REQUIRED)
 find_package(yaml-cpp REQUIRED)
 
-FetchContent_Declare(mapget
-  GIT_REPOSITORY "https://github.com/Klebert-Engineering/mapget"
-  GIT_TAG        "main"
-  GIT_SHALLOW    ON)
-FetchContent_MakeAvailable(mapget)
+# Cesium
+include(cmake/cesium.cmake)
 
-set(CESIUM_TESTS_ENABLED OFF)
-set(CESIUM_GLM_STRICT_ENABLED OFF)
-set(CESIUM_TRACING_ENABLED OFF)
-set(DRACO_JS_GLUE OFF CACHE BOOL "Disable JS glue for Draco" FORCE)
-FetchContent_Declare(
-  cesiumnative
-  GIT_REPOSITORY https://github.com/Klebert-Engineering/cesium-native.git
-  GIT_TAG "spdlog-upgrade"
-  GIT_SHALLOW ON)
-FetchContent_MakeAvailable(cesiumnative)
-
-if (NOT TARGET mapget)
-  if (MAPGET_DIR)
-    FetchContent_Declare(mapget
-      SOURCE_DIR "${MAPGET_DIR}"
-      PATCH_COMMAND conan install "${MAPGET_DIR}" -of "${CMAKE_BINARY_DIR}" --build=missing)
-  else()
-    FetchContent_Declare(mapget
-      GIT_REPOSITORY "https://github.com/Klebert-Engineering/mapget"
-      GIT_TAG        "main"
-      GIT_SHALLOW    ON
-      PATCH_COMMAND conan install "${MAPGET_DIR}" -of "${CMAKE_BINARY_DIR}" --build=missing)
-  endif()
-  FetchContent_MakeAvailable(mapget)
-endif()
-
-# Erdblick Core Library
-
+message("Building for ${CMAKE_SYSTEM_NAME}.")
 add_subdirectory(libs/core)
 
 if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,10 +37,17 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(cesiumnative)
 
 if (NOT TARGET mapget)
-  FetchContent_Declare(mapget
-    GIT_REPOSITORY "https://github.com/Klebert-Engineering/mapget"
-    GIT_TAG        "main"
-    GIT_SHALLOW    ON)
+  if (MAPGET_DIR)
+    FetchContent_Declare(mapget
+      SOURCE_DIR "${MAPGET_DIR}"
+      PATCH_COMMAND conan install "${MAPGET_DIR}" -of "${CMAKE_BINARY_DIR}" --build=missing)
+  else()
+    FetchContent_Declare(mapget
+      GIT_REPOSITORY "https://github.com/Klebert-Engineering/mapget"
+      GIT_TAG        "main"
+      GIT_SHALLOW    ON
+      PATCH_COMMAND conan install "${MAPGET_DIR}" -of "${CMAKE_BINARY_DIR}" --build=missing)
+  endif()
   FetchContent_MakeAvailable(mapget)
 endif()
 

--- a/build-ui.bash
+++ b/build-ui.bash
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
-SOURCE_LOC=$1
-if [ -z $SOURCE_LOC ]; then
+SOURCE_LOC="$1"
+BUILD_DIR="${SOURCE_LOC}/build"
+
+if [ -z "$SOURCE_LOC" ]; then
   echo "No source location supplied."
   exit 1
 fi

--- a/build-ui.bash
+++ b/build-ui.bash
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -eu
 
-NODE_VERSION="21"
 SOURCE_LOC="$1"
 BUILD_DIR="${SOURCE_LOC}/build"
 
@@ -12,15 +11,6 @@ fi
 
 echo "Using source dir @ $SOURCE_LOC."
 cd "$SOURCE_LOC"
-
-echo "Installing nvm"
-export NVM_DIR="$(mktemp -d)"
-git clone https://github.com/nvm-sh/nvm.git "${NVM_DIR}" -b v0.39.7
-. "${NVM_DIR}/nvm.sh"
-
-echo "Setting up Node.js ${NODE_VERSION}"
-nvm install "${NODE_VERSION}"
-nvm use "${NODE_VERSION}"
 
 echo "Collecting npm modules."
 npm -g install --force --include=dev

--- a/build-ui.bash
+++ b/build-ui.bash
@@ -2,7 +2,6 @@
 set -eu
 
 SOURCE_LOC="$1"
-BUILD_DIR="${SOURCE_LOC}/build"
 
 if [ -z "$SOURCE_LOC" ]; then
   echo "No source location supplied."
@@ -13,11 +12,10 @@ echo "Using source dir @ $SOURCE_LOC."
 cd "$SOURCE_LOC"
 
 echo "Collecting npm modules."
-npm -g install --force --include=dev
 npm install
 
 echo "Building Angular distribution files."
-if [[ -z "$NG_DEVELOP" ]]; then
+if [[ -z "${NG_DEVELOP:-}" ]]; then
   npm run build -- -c production
 else
   npm run build

--- a/build-ui.bash
+++ b/build-ui.bash
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -eu
 
+NODE_VERSION="21"
 SOURCE_LOC="$1"
 BUILD_DIR="${SOURCE_LOC}/build"
 
@@ -12,7 +13,17 @@ fi
 echo "Using source dir @ $SOURCE_LOC."
 cd "$SOURCE_LOC"
 
+echo "Installing nvm"
+export NVM_DIR="$(mktemp -d)"
+git clone https://github.com/nvm-sh/nvm.git "${NVM_DIR}" -b v0.39.7
+. "${NVM_DIR}/nvm.sh"
+
+echo "Setting up Node.js ${NODE_VERSION}"
+nvm install "${NODE_VERSION}"
+nvm use "${NODE_VERSION}"
+
 echo "Collecting npm modules."
+npm -g install --force --include=dev
 npm install
 
 echo "Building Angular distribution files."

--- a/build-ui.bash
+++ b/build-ui.bash
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -eu
 
 SOURCE_LOC="$1"
 BUILD_DIR="${SOURCE_LOC}/build"
@@ -9,7 +10,7 @@ if [ -z "$SOURCE_LOC" ]; then
 fi
 
 echo "Using source dir @ $SOURCE_LOC."
-cd "$SOURCE_LOC" || exit 1
+cd "$SOURCE_LOC"
 
 echo "Collecting npm modules."
 npm install
@@ -20,4 +21,3 @@ if [[ -z "$NG_DEVELOP" ]]; then
 else
   npm run build
 fi
-exit 0

--- a/ci/00_linux_setup.bash
+++ b/ci/00_linux_setup.bash
@@ -6,4 +6,5 @@ mkdir -p build/deps
 mkdir -p build/assets
 
 conan install . -pr:b default -pr:h conan-profiles/emscripten.profile \
-    -s build_type=Release -s compiler.cppstd=20 -b missing -of build
+    -s build_type=Release -s compiler.cppstd=20 -b missing -b editable \
+    -of build

--- a/ci/00_linux_setup.bash
+++ b/ci/00_linux_setup.bash
@@ -1,9 +1,15 @@
 #!/usr/bin/env bash
 set -eu
-rm -rf build
-mkdir -p build/deps
-mkdir -p build/assets
 
-conan install . -pr:b default -pr:h conan-profiles/emscripten.profile \
+BUILD_DIR="./build"
+PROFILE_DIR="./conan-profiles"
+
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR/deps"
+mkdir -p "$BUILD_DIR/assets"
+
+conan install . \
+    -pr:b "$PROFILE_DIR/build.profile" \
+    -pr:h "$PROFILE_DIR/emscripten.profile" \
     -s build_type=Release -s compiler.cppstd=20 -b missing -b editable \
-    -of build
+    -of "$BUILD_DIR"

--- a/ci/00_linux_setup.bash
+++ b/ci/00_linux_setup.bash
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 set -eu
-
-rm -rf build && mkdir build
+rm -rf build
 mkdir -p build/deps
 mkdir -p build/assets
 

--- a/ci/00_linux_setup.bash
+++ b/ci/00_linux_setup.bash
@@ -1,12 +1,9 @@
 #!/usr/bin/env bash
+set -eu
 
-ci_dir="$(realpath ${BASH_SOURCE[0]} | xargs -I{} dirname {})"
-echo "Setting up Emscripten in: $ci_dir"
-cd "$ci_dir"
+rm -rf build && mkdir build
+mkdir -p build/deps
+mkdir -p build/assets
 
-git clone https://github.com/emscripten-core/emsdk.git
-cd emsdk
-git pull
-./emsdk install latest
-./emsdk activate latest
-source ./emsdk_env.sh
+conan install . -pr:b default -pr:h conan-profiles/emscripten.profile \
+    -s build_type=Release -b missing -of build

--- a/ci/00_linux_setup.bash
+++ b/ci/00_linux_setup.bash
@@ -6,4 +6,4 @@ mkdir -p build/deps
 mkdir -p build/assets
 
 conan install . -pr:b default -pr:h conan-profiles/emscripten.profile \
-    -s build_type=Release -b missing -of build
+    -s build_type=Release -s compiler.cppstd=20 -b missing -of build

--- a/ci/10_linux_build.bash
+++ b/ci/10_linux_build.bash
@@ -3,10 +3,5 @@ set -e
 source "./build/conanbuild.sh"
 
 set -eu
-
-cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=build/conan_toolchain.cmake \
-    -DBUILD_SHARED_LIBS=OFF \
-    -DCMAKE_CONAN=OFF \
-    -DCMAKE_BUILD_TYPE=Release
-
-cmake --build build -- -j
+cmake --preset conan-release
+cmake --build --preset conan-release -- -j

--- a/ci/10_linux_build.bash
+++ b/ci/10_linux_build.bash
@@ -1,16 +1,12 @@
 #!/usr/bin/env bash
-
 set -e
+source "./build/conanbuild.sh"
 
-ci_dir="$(realpath ${BASH_SOURCE[0]} | xargs -I{} dirname {})"
-source "$ci_dir/emsdk/emsdk_env.sh"
-cd "$ci_dir/.."
+set -eu
 
-export EMSCRIPTEN="$ci_dir/emsdk/upstream/emscripten"
+cmake -S . -B build -DCMAKE_TOOLCHAIN_FILE=build/conan_toolchain.cmake \
+    -DBUILD_SHARED_LIBS=OFF \
+    -DCMAKE_CONAN=OFF \
+    -DCMAKE_BUILD_TYPE=Release
 
-rm -rf build && mkdir build
-cd build
-mkdir deps
-mkdir assets
-emcmake cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF ..
-cmake --build . -- -j
+cmake --build build -- -j

--- a/ci/20_linux_rebuild.bash
+++ b/ci/20_linux_rebuild.bash
@@ -1,11 +1,4 @@
 #!/usr/bin/env bash
+set -eu
 
-set -e
-
-ci_dir="$(realpath ${BASH_SOURCE[0]} | xargs -I{} dirname {})"
-source "$ci_dir/emsdk/emsdk_env.sh"
-
-export EMSCRIPTEN="$ci_dir/emsdk/upstream/emscripten"
-
-cd "$ci_dir/../build"
-cmake --build . -- -j
+cmake --build build -- -j

--- a/ci/20_linux_rebuild.bash
+++ b/ci/20_linux_rebuild.bash
@@ -1,4 +1,3 @@
 #!/usr/bin/env bash
 set -eu
-
-cmake --build build -- -j
+cmake --build --preset conan-release -- -j

--- a/cmake/cesium.cmake
+++ b/cmake/cesium.cmake
@@ -1,0 +1,45 @@
+include(FetchContent)
+include(ExternalProject)
+
+# Use fetch content for cloning the repository durring
+# configure phase. We do not call `FetchContent_MakeAvailable`,
+# but instead use `ExternalProject_Add` to compile Cesium in
+# isolation.
+FetchContent_Declare(cesiumnative_src
+  GIT_REPOSITORY "https://github.com/Klebert-Engineering/cesium-native.git"
+  GIT_TAG "main"
+  GIT_SUBMODULES_RECURSE YES
+  GIT_PROGRESS YES)
+
+FetchContent_GetProperties(cesiumnative_src)
+if (NOT cesiumnative_src_POPULATED)
+  FetchContent_Populate(cesiumnative_src)
+endif()
+
+ExternalProject_Add(cesiumnative
+  SOURCE_DIR ${cesiumnative_src_SOURCE_DIR}
+  CMAKE_ARGS
+    -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+    -DCESIUM_TESTS_ENABLED=OFF
+    -DCESIUM_GLM_STRICT_ENABLED=OFF
+    -DCESIUM_TRACING_ENABLED=OFF
+    -DDRACO_JS_GLUE=OFF
+    #-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE} # FIXME: Is this needed?
+  INSTALL_COMMAND "")
+
+function (add_cesium_lib TARGET)
+  message(STATUS "Adding Cesium library: ${TARGET}")
+  ExternalProject_Get_Property(cesiumnative
+    SOURCE_DIR BINARY_DIR)
+
+  add_library(${TARGET} SHARED IMPORTED)
+  set_target_properties(${TARGET} PROPERTIES
+    IMPORTED_LOCATION "${BINARY_DIR}/${TARGET}/${CMAKE_STATIC_LIBRARY_PREFIX}${TARGET}${CMAKE_STATIC_LIBRARY_SUFFIX}"
+    INTERFACE_INCLUDE_DIRECTORIES "${SOURCE_DIR}/${TARGET}/include")
+endfunction()
+
+add_cesium_lib(CesiumUtility)
+add_cesium_lib(Cesium3DTilesWriter)
+add_cesium_lib(CesiumGeospatial)
+add_cesium_lib(CesiumGltf)
+add_cesium_lib(CesiumGltfWriter)

--- a/cmake/cesium.cmake
+++ b/cmake/cesium.cmake
@@ -30,9 +30,9 @@ ExternalProject_Add(cesiumnative
   STEP_TARGETS build)
 
 function (add_cesium_lib TARGET)
-  message(STATUS "Adding Cesium library: ${TARGET} (${BINARY_DIR}/${TARGET}/${CMAKE_STATIC_LIBRARY_PREFIX}${TARGET}${CMAKE_STATIC_LIBRARY_SUFFIX})")
   ExternalProject_Get_Property(cesiumnative
     SOURCE_DIR BINARY_DIR)
+  message(STATUS "Adding Cesium library: ${TARGET} (${BINARY_DIR}/${TARGET}/${CMAKE_STATIC_LIBRARY_PREFIX}${TARGET}${CMAKE_STATIC_LIBRARY_SUFFIX})")
 
   add_library(${TARGET} STATIC IMPORTED)
   set_target_properties(${TARGET} PROPERTIES

--- a/cmake/cesium.cmake
+++ b/cmake/cesium.cmake
@@ -24,18 +24,21 @@ ExternalProject_Add(cesiumnative
     -DCESIUM_GLM_STRICT_ENABLED=OFF
     -DCESIUM_TRACING_ENABLED=OFF
     -DDRACO_JS_GLUE=OFF
-    #-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE} # FIXME: Is this needed?
-  INSTALL_COMMAND "")
+    -DBUILD_SHARED_LIBS=OFF
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
+  INSTALL_COMMAND ""
+  STEP_TARGETS build)
 
 function (add_cesium_lib TARGET)
-  message(STATUS "Adding Cesium library: ${TARGET}")
+  message(STATUS "Adding Cesium library: ${TARGET} (${BINARY_DIR}/${TARGET}/${CMAKE_STATIC_LIBRARY_PREFIX}${TARGET}${CMAKE_STATIC_LIBRARY_SUFFIX})")
   ExternalProject_Get_Property(cesiumnative
     SOURCE_DIR BINARY_DIR)
 
-  add_library(${TARGET} SHARED IMPORTED)
+  add_library(${TARGET} STATIC IMPORTED)
   set_target_properties(${TARGET} PROPERTIES
     IMPORTED_LOCATION "${BINARY_DIR}/${TARGET}/${CMAKE_STATIC_LIBRARY_PREFIX}${TARGET}${CMAKE_STATIC_LIBRARY_SUFFIX}"
     INTERFACE_INCLUDE_DIRECTORIES "${SOURCE_DIR}/${TARGET}/include")
+  add_dependencies(${TARGET} cesiumnative-build)
 endfunction()
 
 add_cesium_lib(CesiumUtility)

--- a/conan-profiles/build.profile
+++ b/conan-profiles/build.profile
@@ -1,0 +1,7 @@
+include(default)
+
+[settings]
+compiler.cppstd=20
+
+[replace_requires]
+nodejs/*: nodejs/18.15.0

--- a/conan-profiles/emscripten.profile
+++ b/conan-profiles/emscripten.profile
@@ -9,4 +9,4 @@ compiler.cppstd=20
 [tool_requires]
 # See https://github.com/emscripten-core/emsdk/blob/3.1.47/emscripten-releases-tags.json
 # for latest version with linux-arm64 support
-emsdk/3.1.47
+emsdk/3.1.50

--- a/conan-profiles/emscripten.profile
+++ b/conan-profiles/emscripten.profile
@@ -7,4 +7,6 @@ compiler.libcxx=libc++
 compiler.cppstd=20
 
 [tool_requires]
-emsdk/3.1.50
+# See https://github.com/emscripten-core/emsdk/blob/3.1.47/emscripten-releases-tags.json
+# for latest version with linux-arm64 support
+emsdk/3.1.47

--- a/conan-profiles/emscripten.profile
+++ b/conan-profiles/emscripten.profile
@@ -5,10 +5,6 @@ compiler=clang
 compiler.version=15
 compiler.libcxx=libc++
 compiler.cppstd=20
-build_type=Release
 
 [tool_requires]
 emsdk/3.1.50
-
-[replace_tool_requires]
-nodejs/*: nodejs/16.20.2

--- a/conan-profiles/emscripten.profile
+++ b/conan-profiles/emscripten.profile
@@ -1,0 +1,13 @@
+include(default)
+
+[settings]
+os=Emscripten
+arch=wasm
+compiler=clang
+compiler.version=15
+compiler.libcxx=libc++
+build_type=Release
+
+[tool_requires]
+emsdk/3.1.50
+nodejs/16.3.0

--- a/conan-profiles/emscripten.profile
+++ b/conan-profiles/emscripten.profile
@@ -10,8 +10,5 @@ build_type=Release
 [tool_requires]
 emsdk/3.1.50
 
-[replace_requires]
-nodejs/*: nodejs/16.20.2
-
 [replace_tool_requires]
 nodejs/*: nodejs/16.20.2

--- a/conan-profiles/emscripten.profile
+++ b/conan-profiles/emscripten.profile
@@ -1,13 +1,17 @@
-include(default)
-
 [settings]
 os=Emscripten
 arch=wasm
 compiler=clang
 compiler.version=15
 compiler.libcxx=libc++
+compiler.cppstd=20
 build_type=Release
 
 [tool_requires]
 emsdk/3.1.50
-nodejs/16.3.0
+
+[replace_requires]
+nodejs/*: nodejs/16.20.2
+
+[replace_tool_requires]
+nodejs/*: nodejs/16.20.2

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,6 +1,12 @@
 [requires]
+mapget/dev
 glm/cci.20230113
 yaml-cpp/0.8.0
+
+[options]
+mapget/*:with_service=False
+mapget/*:with_httplib=False
+mapget/*:with_wheel=False
 
 [generators]
 CMakeDeps

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,7 @@
+[requires]
+glm/cci.20230113
+yaml-cpp/0.8.0
+
+[generators]
+CMakeDeps
+CMakeToolchain

--- a/libs/core/CMakeLists.txt
+++ b/libs/core/CMakeLists.txt
@@ -74,9 +74,3 @@ target_link_libraries(erdblick-core
     glm::glm
     mapget::model
     yaml-cpp::yaml-cpp)
-
-add_custom_target(erdblick-ui ALL
-    COMMAND bash "${CMAKE_SOURCE_DIR}/build-ui.bash" "${CMAKE_SOURCE_DIR}"
-    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-    DEPENDS erdblick-core
-)

--- a/libs/core/CMakeLists.txt
+++ b/libs/core/CMakeLists.txt
@@ -70,6 +70,13 @@ target_link_libraries(erdblick-core
     CesiumGeospatial
     CesiumGltf
     CesiumGltfWriter
-    glm
-    mapget-model
-    yaml-cpp)
+    CesiumUtility
+    glm::glm
+    mapget::model
+    yaml-cpp::yaml-cpp)
+
+add_custom_target(erdblick-ui ALL
+    COMMAND bash "${CMAKE_SOURCE_DIR}/build-ui.bash" "${CMAKE_SOURCE_DIR}"
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    DEPENDS erdblick-core
+)


### PR DESCRIPTION
Use Conan 2 for package management.

Emscripten + Node.js get installed via Conan. ~~There is currently a problem of Conan packages not allowing to override their tool-requirements, so we install `nvm` and `node.js v21` in the `build-ui.bash` script into a temporary directory to force override the node version Conan installs for us (which is too old for angular). See: https://github.com/conan-io/conan-center-index/issues/23088.~~

This also fixes problems with conflicting CMake targets from cesium by building cesium as an external project (see `cmake/cesium.cmake`).

The cross-build is set up using a Conan profile.

- [ ] Publish mapget to conan.io and use it from there