### PR TITLE
ERD-72: Configuration of proprietary jump targets

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -56,6 +56,11 @@
                                 "output": "/bundle/images"
                             },
                             {
+                                "glob": "config/config.json",
+                                "input": ".",
+                                "output": "/"
+                            },
+                            {
                                 "glob": "VERSION",
                                 "input": ".",
                                 "output": "/bundle/"

--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,0 +1,1 @@
+# Keep this directory to be filled with plugin configurations

--- a/erdblick_app/app/app.module.ts
+++ b/erdblick_app/app/app.module.ts
@@ -20,10 +20,15 @@ import {ToastModule} from "primeng/toast";
 import {MessageService} from "primeng/api";
 import {InputNumberModule} from "primeng/inputnumber";
 import {FieldsetModule} from "primeng/fieldset";
+import {InfoMessageService} from "./info.service";
+import {MenuComponent} from "./menu.component";
+import {JumpTargetService} from "./jump.service";
+import {MapService} from "./map.service";
 
 @NgModule({
     declarations: [
-        AppComponent
+        AppComponent,
+        MenuComponent
     ],
     imports: [
         BrowserModule,
@@ -46,7 +51,10 @@ import {FieldsetModule} from "primeng/fieldset";
         FieldsetModule
     ],
     providers: [
-        MessageService
+        MapService,
+        MessageService,
+        InfoMessageService,
+        JumpTargetService
     ],
     bootstrap: [AppComponent]
 })

--- a/erdblick_app/app/info.service.ts
+++ b/erdblick_app/app/info.service.ts
@@ -1,0 +1,17 @@
+import {Injectable} from "@angular/core";
+import {MessageService} from "primeng/api";
+
+@Injectable({providedIn: 'root'})
+export class InfoMessageService {
+    constructor(private messageService: MessageService) { };
+
+    showError(content: string) {
+        this.messageService.add({ key: 'tc', severity: 'error', summary: 'Error', detail: content });
+        return;
+    }
+
+    showSuccess(content: string) {
+        this.messageService.add({ key: 'tc', severity: 'success', summary: 'Success', detail: content });
+        return;
+    }
+}

--- a/erdblick_app/app/jump.service.ts
+++ b/erdblick_app/app/jump.service.ts
@@ -1,0 +1,46 @@
+import {Injectable} from "@angular/core";
+import {Subject} from "rxjs";
+import {HttpClient} from "@angular/common/http";
+
+export interface JumpTarget {
+    name: string;
+    label: string;
+    enabled: boolean;
+    jump: (value: string) => number[] | undefined;
+    validate: (value: string) => boolean;
+}
+
+@Injectable({providedIn: 'root'})
+export class JumpTargetService {
+
+    targetValueSubject = new Subject<string>();
+    availableOptions = new Subject<Array<JumpTarget>>();
+
+    constructor(private httpClient: HttpClient) {
+        this.targetValueSubject.subscribe(event => {
+            console.log("EVENT: ", event);
+        });
+
+        httpClient.get("/config.json", {responseType: 'json'}).subscribe(
+            {
+                next: (data: any) => {
+                    let jumpTargetsConfig = data["extensionModules"]["jumpTargets"];
+                    if (jumpTargetsConfig !== undefined) {
+                        // Using string interpolation so webpack can trace imports from the location
+                        import(`../../config/${ jumpTargetsConfig }.js`).then(function (plugin) {
+                            return plugin.default() as Array<JumpTarget>;
+                        }).then((jumpTargets: Array<JumpTarget>) => {
+                            this.availableOptions.next(jumpTargets);
+                        }).catch((error) => {
+                            console.log(error);
+                            this.availableOptions.next([]);
+                        });
+                    }
+                },
+                error: error => {
+                    console.log(error);
+                    this.availableOptions.next([]);
+                }
+            });
+    }
+}

--- a/erdblick_app/app/map.service.ts
+++ b/erdblick_app/app/map.service.ts
@@ -1,0 +1,25 @@
+import {Injectable} from "@angular/core";
+import {Subject} from "rxjs";
+import {ErdblickModel} from "./erdblick.model";
+import {ErdblickView} from "./erdblick.view";
+
+@Injectable({providedIn: 'root'})
+export class MapService {
+
+    mapModel: ErdblickModel | undefined;
+    mapView: ErdblickView | undefined;
+    coreLib: any;
+
+    constructor() { }
+
+    collectCameraInfo() {
+        if (this.mapView !== undefined) {
+            return {
+                heading: this.mapView.viewer.camera.heading,
+                pitch: this.mapView.viewer.camera.pitch,
+                roll: this.mapView.viewer.camera.roll
+            };
+        }
+        return null;
+    }
+}

--- a/erdblick_app/app/menu.component.ts
+++ b/erdblick_app/app/menu.component.ts
@@ -1,0 +1,247 @@
+import {Component, OnInit} from "@angular/core";
+import {Cartesian3} from "cesium";
+import {InfoMessageService} from "./info.service";
+import {JumpTarget, JumpTargetService} from "./jump.service";
+import {MapService} from "./map.service";
+
+
+@Component({
+    selector: 'search-menu-items',
+    template: `
+        <div class="search-menu" *ngFor="let item of searchItems">
+            <p-divider></p-divider>
+            <p (click)="jumpToWGS84(item.jump(value))" class="search-option" [ngClass]="{'item-disabled': !item.enabled }"><span>{{item.name}}</span><br>{{item.label}}</p>
+        </div>
+    `,
+    styles: [`
+        .item-disabled {
+            color: lightgrey;
+            pointer-events: none;
+        }
+    `]
+})
+export class MenuComponent {
+
+    searchItems: Array<JumpTarget> = [];
+    value: string = "";
+
+    constructor(private mapService: MapService,
+                private messageService: InfoMessageService,
+                private jumpToTargetService: JumpTargetService) {
+
+        this.jumpToTargetService.targetValueSubject.subscribe((event: string) => {
+            this.value = event;
+            console.log("VALUE: ", this.value);
+            this.validateMenuItems();
+        });
+
+        this.jumpToTargetService.availableOptions.subscribe((jumpTargets: Array<JumpTarget>) => {
+            this.searchItems = [
+                ...jumpTargets,
+                ...[
+                    {
+                        name: "Tile ID",
+                        label: "Jump to Tile by its Mapget ID",
+                        enabled: false,
+                        jump: (value: string) => { return this.parseMapgetTileId(value) },
+                        validate: (value: string) => { return this.validateMapgetTileId(value) }
+                    },
+                    {
+                        name: "WGS84 Lat-Lon Coordinates",
+                        label: "Jump to WGS84 Coordinates",
+                        enabled: false,
+                        jump: (value: string) => { return this.parseWgs84Coordinates(value, false) },
+                        validate: (value: string) => { return this.validateWGS84(value, false) }
+                    },
+                    {
+                        name: "WGS84 Lon-Lat Coordinates",
+                        label: "Jump to WGS84 Coordinates",
+                        enabled: false,
+                        jump: (value: string) => { return this.parseWgs84Coordinates(value, true) },
+                        validate: (value: string) => { return this.validateWGS84(value, true) }
+                    },
+                    {
+                        name: "Open Lat-Lon in Google Maps",
+                        label: "Open Location in External Map Service",
+                        enabled: false,
+                        jump: (value: string) => { return this.openInGM(value) },
+                        validate: (value: string) => { return this.validateGM(value) }
+                    },
+                    {
+                        name: "Open Lat-Lon in Open Street Maps",
+                        label: "Open Location in External Map Service",
+                        enabled: false,
+                        jump: (value: string) => { return this.openInOSM(value) },
+                        validate: (value: string) => { return this.validateOSM(value) }
+                    }
+                ]
+            ];
+        });
+    }
+
+    parseMapgetTileId(value: string): number[] | undefined {
+        if (!value) {
+            this.messageService.showError("No value provided!");
+            return;
+        }
+        if (this.mapService.mapModel !== undefined) {
+            try {
+                let wgs84TileId = BigInt(value);
+                // this.mapService.mapModel.zoomToWgs84PositionTopic.next(this.mapService.coreLib.getTilePosition(wgs84TileId));
+                let position = this.mapService.coreLib.getTilePosition(wgs84TileId);
+                return [position.x, position.y, position.z]
+            } catch (e) {
+                this.messageService.showError("Possibly malformed TileId: " + (e as Error).message.toString());
+            }
+        } else {
+            this.messageService.showError("Cannot access the map model. The model is not available.");
+        }
+        return undefined;
+    }
+
+    parseWgs84Coordinates(coordinateString: string, isLonLat: boolean): number[] | undefined {
+        let lon = 0;
+        let lat = 0;
+        let level = 0;
+        let isMatched = false;
+        coordinateString = coordinateString.trim();
+
+        // WGS (decimal)
+        let exp = /^[^\d-]*(-?\d+(?:\.\d*)?)[^\d-]+(-?\d+(?:\.\d*)?)[^\d\.]*(\d+)?[^\d]*$/g;
+        let matches = [...coordinateString.matchAll(exp)];
+        if (matches.length > 0) {
+            let matchResults = matches[0];
+            if (matchResults.length >= 3) {
+                if (isLonLat) {
+                    lon = Number(matchResults[1]);
+                    lat = Number(matchResults[2]);
+                } else {
+                    lon = Number(matchResults[2]);
+                    lat = Number(matchResults[1]);
+                }
+
+                if (matchResults.length >= 4 && matchResults[3] !== undefined) {
+                    // Zoom level provided.
+                    level = Math.max(1, Math.min(Number(matchResults[3].toString()), 14));
+                }
+                isMatched = true;
+            }
+        }
+
+        // WGS (degree)
+        if (isLonLat) {
+            exp = /([1-9][0-9]{0,2}|0)°([0-5]{0,1}[0-9])'((?:[0-5]{0,1}[0-9])(?:.{1}[0-9][0-9]{0,3})?)["]([WE])\s*([1-9][0-9]{0,2}|0)°([0-5]{0,1}[0-9])'((?:[0-5]{0,1}[0-9])(?:.{1}[0-9][0-9]{0,3})?)["]([NS])[^\d\.]*(\d+)?[^\d]*$/g;
+        } else {
+            exp = /([1-9][0-9]{0,2}|0)°([0-5]{0,1}[0-9])'((?:[0-5]{0,1}[0-9])(?:.{1}[0-9][0-9]{0,3})?)["]([NS])\s*([1-9][0-9]{0,2}|0)°([0-5]{0,1}[0-9])'((?:[0-5]{0,1}[0-9])(?:.{1}[0-9][0-9]{0,3})?)["]([WE])[^\d\.]*(\d+)?[^\d]*$/g;
+        }
+        matches = [...coordinateString.matchAll(exp)];
+        if (!isMatched && matches.length > 0) {
+            let matchResults = matches[0];
+            if (matchResults.length >= 9) {
+                let degreeLon = isLonLat ? Number(matchResults[1]) : Number(matchResults[5]);
+                let minutesLon = isLonLat ? Number(matchResults[2]) : Number(matchResults[6]);
+                let secondsLon = isLonLat ? Number(matchResults[3]) : Number(matchResults[7]);
+                let degreeLat = isLonLat ? Number(matchResults[5]) : Number(matchResults[1]);
+                let minutesLat = isLonLat ? Number(matchResults[6]) : Number(matchResults[2]);
+                let secondsLat = isLonLat ? Number(matchResults[7]) : Number(matchResults[3]);
+
+                lat = degreeLat + (minutesLat * 60.0 + secondsLat) / 3600.0;
+                if (matchResults[4][0] == 'S') {
+                    lat = -lat;
+                }
+
+                lon = degreeLon + (minutesLon * 60.0 + secondsLon) / 3600.0;
+                if (matchResults[8][0] == 'W') {
+                    lon = -lon;
+                }
+
+                if (matchResults.length >= 10 && matchResults[9] !== undefined) {
+                    // Zoom level provided.
+                    level = Math.max(1, Math.min(Number(matchResults[9].toString()), 14));
+                }
+
+                isMatched = true;
+            }
+        }
+
+        if (isMatched) {
+            return [lat, lon, level];
+        }
+        return undefined;
+    }
+
+    jumpToWGS84(coordinates: number[] | undefined) {
+        if (coordinates === undefined) {
+            this.messageService.showError("Could not parse coordinates from the input.");
+            return;
+        } else {
+            let lat = coordinates[0];
+            let lon = coordinates[1];
+            let alt = coordinates.length > 2 && coordinates[2] > 0 ? coordinates[2] : 15000;
+            let position = Cartesian3.fromDegrees(lon, lat, alt);
+            let orientation = this.mapService.collectCameraInfo();
+            if (orientation) {
+                if (this.mapService.mapView !== undefined) {
+                    this.mapService.mapView.viewer.camera.setView({
+                        destination: position,
+                        orientation: orientation
+                    });
+                } else {
+                    this.messageService.showError("Cannot set camera information. The view is not available.");
+                }
+            }
+        }
+    }
+
+    openInGM(value: string): number[] | undefined {
+        if (!value) {
+            this.messageService.showError("No value provided!");
+            return undefined;
+        }
+        let result = this.parseWgs84Coordinates(value, false);
+        if (result !== undefined) {
+            let lat = result[0];
+            let lon = result[1];
+            window.open(`https://www.google.com/maps/search/?api=1&query=${lat},${lon}`, "_blank");
+            return result;
+        }
+        return undefined;
+    }
+
+    openInOSM(value: string): number[] | undefined {
+        if (!value) {
+            this.messageService.showError("No value provided!");
+            return;
+        }
+        let result = this.parseWgs84Coordinates(value, false);
+        if (result !== undefined) {
+            let lat = result[0];
+            let lon = result[1];
+            window.open(`https://www.openstreetmap.org/?mlat=${lat}&mlon=${lon}&zoom=16`, "_blank");
+            return result;
+        }
+        return undefined;
+    }
+
+    validateMenuItems() {
+        this.searchItems.forEach(item =>
+            item.enabled = this.value != "" && item.validate(this.value)
+        );
+    }
+
+    validateMapgetTileId(value: string) {
+        return value.length > 0 && !/\s/g.test(value.trim());
+    }
+
+    validateWGS84(value: string, isLonLat: boolean = false) {
+        return this.parseWgs84Coordinates(value, isLonLat) !== undefined;
+    }
+
+    validateGM(value: string) {
+        return this.parseWgs84Coordinates(value, false) !== undefined;
+    }
+
+    validateOSM(value: string) {
+        return this.parseWgs84Coordinates(value, false) !== undefined;
+    }
+}

--- a/erdblick_app/styles.scss
+++ b/erdblick_app/styles.scss
@@ -206,8 +206,8 @@ body {
     }
 }
 
-.p-overlaypanel-content {
-    & > div:first-child {
+.search-menu {
+    &:first-child {
         .p-divider {
             display: none;
         }
@@ -215,7 +215,7 @@ body {
 
     .search-option {
         text-align: left;
-        font-size: medium;
+        font-size: small;
         margin: 0;
         background: none;
         border: none;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "compilerOptions": {
         "baseUrl": "./",
         "outDir": "./static/out-tsc",
+        "allowJs": true,
         "forceConsistentCasingInFileNames": true,
         "strict": true,
         "strictNullChecks": true,


### PR DESCRIPTION
**Goal**: erdblick needs to support jumping to proprietary coordinates, which are represented by closed-source formats.

**Scope**:
[ERD-72](https://youtrack.nds-association.org/issue/ERD-72) Configuration of proprietary jump targets
* Erdblick components and services 

**Deliverables**:
* Refactored app component.
* Menu items components.
* Information messages, map-related and jump targets Angular services.

**How to test**:
1. Build and run as usual (without a plugin).

OR

1. Copy plugin files from mapviewer repository to _config_ directory.
2. Build and run as usual (with a plugin).

OR

1. Test via mapviewer build (with a plugin).

**Notes**:
* _config_ directory needs to be present for correct path resolution by webpack (using dynamic import).