### PR TITLE
Performant Handling of WASM Exceptions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,15 +24,6 @@ FetchContent_Declare(glm
     GIT_SHALLOW    ON)
 FetchContent_MakeAvailable(glm)
 
-set(SIMFIL_WITH_MODEL_JSON YES)
-if (NOT TARGET simfil)
-  FetchContent_Declare(simfil
-    GIT_REPOSITORY "https://github.com/Klebert-Engineering/simfil.git"
-    GIT_TAG        "exception-handler"
-    GIT_SHALLOW    ON)
-  FetchContent_MakeAvailable(simfil)
-endif()
-
 FetchContent_Declare(mapget
   GIT_REPOSITORY "https://github.com/Klebert-Engineering/mapget"
   GIT_TAG        "relations"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,15 @@ FetchContent_Declare(glm
     GIT_SHALLOW    ON)
 FetchContent_MakeAvailable(glm)
 
+set(SIMFIL_WITH_MODEL_JSON YES)
+if (NOT TARGET simfil)
+  FetchContent_Declare(simfil
+    GIT_REPOSITORY "https://github.com/Klebert-Engineering/simfil.git"
+    GIT_TAG        "exception-handler"
+    GIT_SHALLOW    ON)
+  FetchContent_MakeAvailable(simfil)
+endif()
+
 FetchContent_Declare(mapget
   GIT_REPOSITORY "https://github.com/Klebert-Engineering/mapget"
   GIT_TAG        "relations"

--- a/erdblick_app/app/app.component.ts
+++ b/erdblick_app/app/app.component.ts
@@ -71,6 +71,10 @@ export class AppComponent {
             console.log("  ...done.")
             this.mapService.coreLib = coreLib;
 
+            coreLib.setExceptionHandler((excType: string, message: string) => {
+                throw new Error(`${excType}: ${message}`);
+            });
+
             this.styleService.stylesLoaded.subscribe(loaded => {
                 if (loaded) this.init();
             });

--- a/erdblick_app/app/visualization.component.ts
+++ b/erdblick_app/app/visualization.component.ts
@@ -88,7 +88,13 @@ export class TileVisualization {
                     this.style,
                     this.highlight!);
                 visualization.addTileFeatureLayer(tileFeatureLayer);
-                visualization.run();
+                try {
+                    visualization.run();
+                }
+                catch (e) {
+                    console.log(`Exception while rendering: ${e}`);
+                    return false;
+                }
 
                 // Try to resolve externally referenced auxiliary tiles.
                 let extRefs = {requests: visualization.externalReferences()};
@@ -131,7 +137,13 @@ export class TileVisualization {
                     await FeatureTile.peekMany(auxTiles, async (tileFeatureLayers: Array<TileFeatureLayer>) => {
                         for (let auxTile of tileFeatureLayers)
                             visualization.addTileFeatureLayer(auxTile);
-                        visualization.processResolvedExternalReferences(extRefsResolved.responses);
+
+                        try {
+                            visualization.processResolvedExternalReferences(extRefsResolved.responses);
+                        }
+                        catch (e) {
+                            console.log(`Exception while rendering: ${e}`);
+                        }
                     });
                 }
                 this.primitiveCollection = visualization.primitiveCollection();

--- a/libs/core/src/bindings.cpp
+++ b/libs/core/src/bindings.cpp
@@ -9,6 +9,7 @@
 
 #include "cesium-interface/point-conversion.h"
 #include "cesium-interface/primitive.h"
+#include "simfil/exception-handler.h"
 
 #include "mapget/log.h"
 
@@ -114,6 +115,13 @@ void generateTestTile(SharedUint8Array& output, TileLayerParser& parser) {
 /** Create a test style. */
 FeatureLayerStyle generateTestStyle() {
     return TestDataProvider::style();
+}
+
+/** Create a test style. */
+void setExceptionHandler(em::val handler) {
+    simfil::ThrowHandler::instance().set([handler](auto&& type, auto&& message){
+        handler(type, message);
+    });
 }
 
 EMSCRIPTEN_BINDINGS(erdblick)
@@ -236,4 +244,7 @@ EMSCRIPTEN_BINDINGS(erdblick)
     ////////// Get a test tile/style
     em::function("generateTestTile", &generateTestTile);
     em::function("generateTestStyle", &generateTestStyle);
+
+    ////////// Set an exception handler
+    em::function("setExceptionHandler", &setExceptionHandler);
 }


### PR DESCRIPTION
This Workaround based on the new simfil exception callback allows us to bypass exception handling in Web Assembly. WASM exception handling currently slows down the browser engine by 1000x as soon as any exception is thrown from C++. So we throw the exception from a JS callback instead.