### PR TITLE
Persist coordinate panel settings

### DIFF
--- a/erdblick_app/app/app.component.ts
+++ b/erdblick_app/app/app.component.ts
@@ -68,7 +68,9 @@ export class AppComponent {
             if (!this.parametersService.initialQueryParamsSet) {
                 return;
             }
-            const entries = [...Object.entries(parameters)];
+            const entries = [...Object.entries(parameters)].filter(value =>
+                this.parametersService.isUrlParameter(value[0])
+            );
             entries.forEach(entry => entry[1] = JSON.stringify(entry[1]));
             this.updateQueryParams(Object.fromEntries(entries), this.parametersService.replaceUrl);
         });

--- a/erdblick_app/app/app.module.ts
+++ b/erdblick_app/app/app.module.ts
@@ -50,9 +50,10 @@ import {FeatureSearchService} from "./feature.search.service";
 import {ClipboardService} from "./clipboard.service";
 import {MultiSelectModule} from "primeng/multiselect";
 
-export function initializeServices(styleService: StyleService, mapService: MapService) {
+export function initializeServices(styleService: StyleService, mapService: MapService, coordService: CoordinatesService) {
     return async () => {
         await initializeLibrary();
+        coordService.initialize();
         await styleService.initializeStyles();
         await mapService.initialize();
     }
@@ -104,7 +105,7 @@ export function initializeServices(styleService: StyleService, mapService: MapSe
         {
             provide: APP_INITIALIZER,
             useFactory: initializeServices,
-            deps: [StyleService, MapService],
+            deps: [StyleService, MapService, CoordinatesService],
             multi: true
         },
         MapService,
@@ -114,7 +115,6 @@ export function initializeServices(styleService: StyleService, mapService: MapSe
         InspectionService,
         ParametersService,
         SidePanelService,
-        CoordinatesService,
         FeatureSearchService,
         ClipboardService
     ],

--- a/erdblick_app/app/coordinates.panel.component.ts
+++ b/erdblick_app/app/coordinates.panel.component.ts
@@ -149,10 +149,10 @@ export class CoordinatesPanelComponent {
             this.mapgetTileIds.set(`Mapget TileId (level ${level})`,
                 coreLib.getTileIdFromPosition(this.longitude, this.latitude, level));
         }
-        if (this.coordinatesService.auxilaryTileIdsFun) {
+        if (this.coordinatesService.auxiliaryTileIdsFun) {
             for (let level = 0; level < 15; level++) {
                 const levelData: Map<string, bigint> =
-                    this.coordinatesService.auxilaryTileIdsFun(this.longitude, this.latitude, level).reduce(
+                    this.coordinatesService.auxiliaryTileIdsFun(this.longitude, this.latitude, level).reduce(
                         (map: Map<string, bigint>, [key, value]: [string, bigint]) => {
                             map.set(key, value);
                             return map;

--- a/erdblick_app/app/coordinates.panel.component.ts
+++ b/erdblick_app/app/coordinates.panel.component.ts
@@ -108,18 +108,24 @@ export class CoordinatesPanelComponent {
                     this.markerButtonTooltip = "Disable marker placement";
                 }
                 this.markerPosition = null;
+                this.updateValues();
             }
+            this.restoreSelectedOptions();
         });
+
         this.coordinatesService.mouseMoveCoordinates.subscribe(coordinates => {
             if (!this.markerPosition && coordinates) {
                 this.longitude = CesiumMath.toDegrees(coordinates.longitude);
                 this.latitude = CesiumMath.toDegrees(coordinates.latitude);
                 this.updateValues();
             }
+            this.restoreSelectedOptions();
         });
+    }
 
+    private restoreSelectedOptions() {
         for (const option of this.parametersService.getCoordinatesAndTileIds()) {
-            if (this.displayOptions.some(val => val.name == option) && !this.isSelectedOption(option)) {
+            if (!this.isSelectedOption(option) && this.displayOptions.some(val => val.name == option)) {
                 this.selectedOptions.push({name: option});
             }
         }

--- a/erdblick_app/app/coordinates.panel.component.ts
+++ b/erdblick_app/app/coordinates.panel.component.ts
@@ -17,12 +17,12 @@ interface PanelOption {
         <div class="coordinates-container">
             <p-button (click)="toggleMarker()" label="" [pTooltip]="markerButtonTooltip" tooltipPosition="bottom"
                       [style]="{'padding-left': '0', 'padding-right': '0', width: '2em', height: '2em', 'box-shadow': 'none'}">
-                <span class="material-icons" style="font-size: 1.2em; margin: 0 auto;">{{markerButtonIcon}}</span>
+                <span class="material-icons" style="font-size: 1.2em; margin: 0 auto;">{{ markerButtonIcon }}</span>
             </p-button>
             <p-card *ngIf="longitude && latitude" xmlns="http://www.w3.org/1999/html"
                     class="coordinates-panel">
                 <p-multiSelect dropdownIcon="pi pi-list-check" [options]="displayOptions" [(ngModel)]="selectedOptions"
-                               (ngModelChange)="updateSelectedOptions()" optionLabel="name" placeholder="" 
+                               (ngModelChange)="updateSelectedOptions()" optionLabel="name" placeholder=""
                                class="coordinates-select" appendTo="body"/>
                 <div class="coordinates-entries">
                     <div class="coordinates-entry" *ngIf="isSelectedOption('WGS84')">
@@ -30,27 +30,32 @@ interface PanelOption {
                         <span class="coord-span">{{ longitude.toFixed(8) }}</span>
                         <span class="coord-span">{{ latitude.toFixed(8) }}</span>
                     </div>
-                    <ng-container *ngFor="let coords of auxillaryCoordinates | keyvalue" >
+                    <ng-container *ngFor="let coords of auxiliaryCoordinates | keyvalue">
                         <div *ngIf="isSelectedOption(coords.key)" class="coordinates-entry">
                             <span class="name-span" (click)="copyToClipboard(coords.value)">{{ coords.key }}:</span>
                             <span *ngFor="let component of coords.value" class="coord-span">{{ component }}</span>
                         </div>
                     </ng-container>
-                    <ng-container *ngFor="let tileId of mapgetTileIds | keyvalue" >
+                    <ng-container *ngFor="let tileId of mapgetTileIds | keyvalue">
                         <div *ngIf="isSelectedOption(tileId.key)" class="coordinates-entry">
-                            <span class="name-span" (click)="clipboardService.copyToClipboard(tileId.value.toString())">{{ tileId.key }}:</span>
+                            <span class="name-span"
+                                  (click)="clipboardService.copyToClipboard(tileId.value.toString())">{{ tileId.key }}
+                                :</span>
                             <span class="coord-span">{{ tileId.value }}</span>
                         </div>
                     </ng-container>
-                    <ng-container *ngFor="let tileId of auxillaryTileIds | keyvalue" >
+                    <ng-container *ngFor="let tileId of auxiliaryTileIds | keyvalue">
                         <div *ngIf="isSelectedOption(tileId.key)" class="coordinates-entry">
-                            <span class="name-span" (click)="clipboardService.copyToClipboard(tileId.value.toString())">{{ tileId.key }}:</span>
+                            <span class="name-span"
+                                  (click)="clipboardService.copyToClipboard(tileId.value.toString())">{{ tileId.key }}
+                                :</span>
                             <span class="coord-span">{{ tileId.value }}</span>
                         </div>
                     </ng-container>
                 </div>
             </p-card>
-            <p-button *ngIf="isMarkerEnabled && markerPosition" (click)="mapService.moveToWgs84PositionTopic.next(markerPosition)"
+            <p-button *ngIf="isMarkerEnabled && markerPosition"
+                      (click)="mapService.moveToWgs84PositionTopic.next(markerPosition)"
                       label="" pTooltip="Focus on marker" tooltipPosition="bottom"
                       [style]="{'padding-left': '0', 'padding-right': '0', width: '2em', height: '2em', 'box-shadow': 'none'}">
                 <span class="material-icons" style="font-size: 1.2em; margin: 0 auto;">loupe</span>
@@ -76,9 +81,9 @@ export class CoordinatesPanelComponent {
     latitude: number = 0;
     isMarkerEnabled: boolean = false;
     markerPosition: {x: number, y: number} | null = null;
-    auxillaryCoordinates: Map<string, Array<number>> = new Map<string, Array<number>>();
+    auxiliaryCoordinates: Map<string, Array<number>> = new Map<string, Array<number>>();
     mapgetTileIds: Map<string, bigint> = new Map<string, bigint>();
-    auxillaryTileIds: Map<string, bigint> = new Map<string, bigint>();
+    auxiliaryTileIds: Map<string, bigint> = new Map<string, bigint>();
     markerButtonIcon: string = "location_off";
     markerButtonTooltip: string = "Enable marker placement";
     displayOptions: Array<PanelOption> = [{name: "WGS84"}];
@@ -133,13 +138,13 @@ export class CoordinatesPanelComponent {
 
     private updateValues() {
         if (this.coordinatesService.auxiliaryCoordinatesFun) {
-            this.auxillaryCoordinates =
+            this.auxiliaryCoordinates =
                 this.coordinatesService.auxiliaryCoordinatesFun(this.longitude, this.latitude).reduce(
                     (map: Map<string, Array<number>>, [key, value]: [string, Array<number>]) => {
                         map.set(key, value);
                         return map;
                     }, new Map<string, Array<number>>());
-            for (const key of this.auxillaryCoordinates.keys()) {
+            for (const key of this.auxiliaryCoordinates.keys()) {
                 if (!this.displayOptions.some(val => val.name == key)) {
                     this.displayOptions.push({name: `${key}`});
                 }
@@ -159,10 +164,10 @@ export class CoordinatesPanelComponent {
                         }, new Map<string, bigint>());
 
                 levelData.forEach((value, key) => {
-                    this.auxillaryTileIds.set(`${key} (level ${level})`, value);
+                    this.auxiliaryTileIds.set(`${key} (level ${level})`, value);
                 });
             }
-            for (const key of this.auxillaryTileIds.keys()) {
+            for (const key of this.auxiliaryTileIds.keys()) {
                 if (!this.displayOptions.some(val => val.name == key)) {
                     this.displayOptions.push({name: key});
                 }

--- a/erdblick_app/app/coordinates.panel.component.ts
+++ b/erdblick_app/app/coordinates.panel.component.ts
@@ -143,10 +143,10 @@ export class CoordinatesPanelComponent {
             this.mapgetTileIds.set(`Mapget TileId (level ${level})`,
                 coreLib.getTileIdFromPosition(this.longitude, this.latitude, level));
         }
-        if (this.coordinatesService.auxillaryTileIdsFun) {
+        if (this.coordinatesService.auxilaryTileIdsFun) {
             for (let level = 0; level < 15; level++) {
                 const levelData: Map<string, bigint> =
-                    this.coordinatesService.auxillaryTileIdsFun(this.longitude, this.latitude, level).reduce(
+                    this.coordinatesService.auxilaryTileIdsFun(this.longitude, this.latitude, level).reduce(
                         (map: Map<string, bigint>, [key, value]: [string, bigint]) => {
                             map.set(key, value);
                             return map;

--- a/erdblick_app/app/coordinates.service.ts
+++ b/erdblick_app/app/coordinates.service.ts
@@ -10,7 +10,7 @@ export class CoordinatesService {
     mouseMoveCoordinates: BehaviorSubject<Cartographic | null> = new BehaviorSubject<Cartographic | null>(null);
     mouseClickCoordinates: BehaviorSubject<Cartographic | null> = new BehaviorSubject<Cartographic | null>(null);
     auxiliaryCoordinatesFun: Function | null = null;
-    auxilaryTileIdsFun: Function | null = null;
+    auxiliaryTileIdsFun: Function | null = null;
 
     constructor(private httpClient: HttpClient,
                 public parametersService: ParametersService) {
@@ -35,7 +35,7 @@ export class CoordinatesService {
                                     console.error('Function getAuxCoordinates not found in the plugin.');
                                 }
                                 if (getAuxTileIds) {
-                                    this.auxilaryTileIdsFun = getAuxTileIds;
+                                    this.auxiliaryTileIdsFun = getAuxTileIds;
                                 } else {
                                     console.error('Function getAuxTileIds not found in the plugin.');
                                 }

--- a/erdblick_app/app/coordinates.service.ts
+++ b/erdblick_app/app/coordinates.service.ts
@@ -10,7 +10,7 @@ export class CoordinatesService {
     mouseMoveCoordinates: BehaviorSubject<Cartographic | null> = new BehaviorSubject<Cartographic | null>(null);
     mouseClickCoordinates: BehaviorSubject<Cartographic | null> = new BehaviorSubject<Cartographic | null>(null);
     auxiliaryCoordinatesFun: Function | null = null;
-    auxillaryTileIdsFun: Function | null = null;
+    auxilaryTileIdsFun: Function | null = null;
 
     constructor(private httpClient: HttpClient,
                 public parametersService: ParametersService) {
@@ -35,7 +35,7 @@ export class CoordinatesService {
                                     console.error('Function getAuxCoordinates not found in the plugin.');
                                 }
                                 if (getAuxTileIds) {
-                                    this.auxillaryTileIdsFun = getAuxTileIds;
+                                    this.auxilaryTileIdsFun = getAuxTileIds;
                                 } else {
                                     console.error('Function getAuxTileIds not found in the plugin.');
                                 }

--- a/erdblick_app/app/coordinates.service.ts
+++ b/erdblick_app/app/coordinates.service.ts
@@ -5,7 +5,7 @@ import {Cartographic} from "./cesium";
 import {HttpClient} from "@angular/common/http";
 
 
-@Injectable()
+@Injectable({providedIn: 'root'})
 export class CoordinatesService {
     mouseMoveCoordinates: BehaviorSubject<Cartographic | null> = new BehaviorSubject<Cartographic | null>(null);
     mouseClickCoordinates: BehaviorSubject<Cartographic | null> = new BehaviorSubject<Cartographic | null>(null);
@@ -14,6 +14,12 @@ export class CoordinatesService {
 
     constructor(private httpClient: HttpClient,
                 public parametersService: ParametersService) {
+        this.mouseClickCoordinates.subscribe(position => {
+            this.parametersService.setMarkerPosition(position);
+        });
+    }
+
+    initialize() {
         this.httpClient.get("/config.json", {responseType: 'json'}).subscribe({
             next: (data: any) => {
                 try {
@@ -46,11 +52,5 @@ export class CoordinatesService {
                 console.error(error);
             }
         });
-
-        this.mouseClickCoordinates.subscribe(position => {
-            this.parametersService.setMarkerPosition(position);
-        });
     }
-
-
 }

--- a/erdblick_app/app/parameters.service.ts
+++ b/erdblick_app/app/parameters.service.ts
@@ -9,7 +9,6 @@ export const MAX_NUM_TILES_TO_VISUALIZE = 512;
 interface ErdblickParameters extends Record<string, any> {
     marker: boolean,
     markedPosition: Array<number>,
-    markedPositionLabels: Array<string>,
     selected: Array<string>,
     heading: number,
     pitch: number,
@@ -49,11 +48,6 @@ const erdblickParameters: Record<string, ParameterDescriptor> = {
         validator: val => Array.isArray(val) && val.every(item => typeof item === 'number'),
         default: [],
         urlParam: true
-    },
-    markedPositionLabels: {
-        converter: val => JSON.parse(val),
-        validator: val => Array.isArray(val) && val.every(item => typeof item === 'string'),
-        default: []
     },
     selected: {
         converter: val => JSON.parse(val),

--- a/erdblick_app/app/parameters.service.ts
+++ b/erdblick_app/app/parameters.service.ts
@@ -21,7 +21,8 @@ interface ErdblickParameters extends Record<string, any> {
     layers: Array<[string, number, boolean, boolean]>,
     styles: Array<string>,
     tilesLoadLimit: number,
-    tilesVisualizeLimit: number
+    tilesVisualizeLimit: number,
+    enabledCoordsTileIds: Array<string>
 }
 
 interface ParameterDescriptor {
@@ -30,84 +31,107 @@ interface ParameterDescriptor {
     // Check if the converted value is good, or the default must be used.
     validator: (val: any)=>boolean,
     // Default value.
-    default: any
+    default: any,
+    // Include in the url
+    urlParam: boolean
 }
 
 const erdblickParameters: Record<string, ParameterDescriptor> = {
     marker: {
         converter: val => val === 'true',
         validator: val => typeof val === 'boolean',
-        default: false
+        default: false,
+        urlParam: true
     },
     marked_position: {
         converter: val => JSON.parse(val),
         validator: val => Array.isArray(val) && val.every(item => typeof item === 'number'),
-        default: []
+        default: [],
+        urlParam: true
     },
     selected: {
         converter: val => JSON.parse(val),
         validator: val => Array.isArray(val) && val.every(item => typeof item === 'string'),
-        default: []
+        default: [],
+        urlParam: true
     },
     heading: {
         converter: Number,
         validator: val => typeof val === 'number' && !isNaN(val),
-        default: 6.0
+        default: 6.0,
+        urlParam: true
     },
     pitch: {
         converter: Number,
         validator: val => typeof val === 'number' && !isNaN(val),
-        default: -1.55
+        default: -1.55,
+        urlParam: true
     },
     roll: {
         converter: Number,
         validator: val => typeof val === 'number' && !isNaN(val),
-        default: 0.25
+        default: 0.25,
+        urlParam: true
     },
     lon: {
         converter: Number,
         validator: val => typeof val === 'number' && !isNaN(val),
-        default: 22.837473
+        default: 22.837473,
+        urlParam: true
     },
     lat: {
         converter: Number,
         validator: val => typeof val === 'number' && !isNaN(val),
-        default: 38.490817
+        default: 38.490817,
+        urlParam: true
     },
     alt: {
         converter: Number,
         validator: val => typeof val === 'number' && !isNaN(val),
-        default: 16000000
+        default: 16000000,
+        urlParam: true
     },
     osmOpacity: {
         converter: Number,
         validator: val => typeof val === 'number' && !isNaN(val) && val >= 0 && val <= 100,
-        default: 30
+        default: 30,
+        urlParam: true
     },
     osm: {
         converter: val => val === 'true',
         validator: val => typeof val === 'boolean',
-        default: true
+        default: true,
+        urlParam: true
     },
     layers: {
         converter: val => JSON.parse(val),
         validator: val => Array.isArray(val) && val.every(item => Array.isArray(item) && item.length === 4 && typeof item[0] === 'string' && typeof item[1] === 'number' && typeof item[2] === 'boolean' && typeof item[3] === 'boolean'),
-        default: []
+        default: [],
+        urlParam: true
     },
     styles: {
         converter: val => JSON.parse(val),
         validator: val => Array.isArray(val) && val.every(item => typeof item === 'string'),
-        default: []
+        default: [],
+        urlParam: true
     },
     tilesLoadLimit: {
         converter: Number,
         validator: val => typeof val === 'number' && !isNaN(val) && val >= 0,
-        default: MAX_NUM_TILES_TO_LOAD
+        default: MAX_NUM_TILES_TO_LOAD,
+        urlParam: true
     },
     tilesVisualizeLimit: {
         converter: Number,
         validator: val => typeof val === 'number' && !isNaN(val) && val >= 0,
-        default: MAX_NUM_TILES_TO_VISUALIZE
+        default: MAX_NUM_TILES_TO_VISUALIZE,
+        urlParam: true
+    },
+    enabledCoordsTileIds: {
+        converter: val => JSON.parse(val),
+        validator: val => Array.isArray(val) && val.every(item => typeof item === 'string'),
+        default: ["WGS84"],
+        urlParam: false
     }
 };
 
@@ -318,5 +342,21 @@ export class ParametersService {
 
     getCameraPosition() {
         return this.cameraViewData.getValue().destination;
+    }
+
+    setCoordinatesAndTileIds(selectedOptions: Array<string>) {
+        this.p().enabledCoordsTileIds = selectedOptions;
+        this.parameters.next(this.p());
+    }
+
+    getCoordinatesAndTileIds() {
+        return this.p().enabledCoordsTileIds;
+    }
+
+    isUrlParameter(name: string) {
+        if (erdblickParameters.hasOwnProperty(name)) {
+            return erdblickParameters[name].urlParam;
+        }
+        return false;
     }
 }

--- a/erdblick_app/styles.scss
+++ b/erdblick_app/styles.scss
@@ -41,40 +41,6 @@ body {
 }
 
 /* Shared styles for both panels */
-.panel {
-    color: white;
-    font-size: large;
-    background-color: rgba(91, 91, 91, 0.7);
-    font-family: monospace;
-    position: absolute;
-    top: 10px;
-    border-radius: 10px;
-    overflow: hidden;
-    height: 22px;
-    padding: 1em;
-    width: calc(50% - 65px);
-}
-
-.panel.expanded {
-    max-height: calc(100vh - 60px);
-    height: auto;
-}
-
-@media (max-width: 768px) {
-    .panel {
-        width: calc(100% - 70px);
-        position: relative;
-        left: auto !important;
-        right: auto !important;
-        top: auto;
-        margin: 10px;
-    }
-
-    .panel.expanded {
-        max-height: calc(100vh - 120px);
-    }
-}
-
 #info {
     position: absolute;
     right: 0;
@@ -89,18 +55,6 @@ body {
     line-height: 1.5em;
     padding-bottom: 0.25em;
     border-radius: 5px 0 0 0;
-}
-
-.p-speeddial-direction-up {
-    &.speeddial-left {
-        left: 0.5em;
-        bottom: 5em;
-    }
-
-    .p-speeddial-button {
-        width: 3em;
-        height: 3em;
-    }
 }
 
 .help-button {


### PR DESCRIPTION
**Goal**: save selected coordinates/tile IDs and reconfigure on reload.

**Scope**:
- #132 #136

**Deliverables**:
- Coordinates panel component and service.
- Parameters service.

**How to test**:
1. Build with as usual.
2. Serve with mapget.

**Notes**:
* For testing auxiliary coordinates, it requires a plugin.