### PR TITLE
cmake: Use external project for building cesium

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -21,6 +21,9 @@ jobs:
           cache: "npm"
           cache-dependency-path: package-lock.json
 
+      - name: Install build dependencies
+        run: sudo apt-get install ninja-build
+
       - name: Install npm dependencies
         run: npm -g install --force --include=dev
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,22 +24,13 @@ FetchContent_Declare(mapget
   GIT_SHALLOW    ON)
 FetchContent_MakeAvailable(mapget)
 
-set(CESIUM_TESTS_ENABLED OFF)
-set(CESIUM_GLM_STRICT_ENABLED OFF)
-set(CESIUM_TRACING_ENABLED OFF)
-set(DRACO_JS_GLUE OFF CACHE BOOL "Disable JS glue for Draco" FORCE)
-FetchContent_Declare(
-  cesiumnative
-  GIT_REPOSITORY https://github.com/Klebert-Engineering/cesium-native.git
-  GIT_TAG "spdlog-upgrade"
-  GIT_SHALLOW ON)
-FetchContent_MakeAvailable(cesiumnative)
-
 FetchContent_Declare(yaml-cpp
   GIT_REPOSITORY "https://github.com/jbeder/yaml-cpp.git"
   GIT_TAG        "yaml-cpp-0.7.0"
   GIT_SHALLOW    ON)
 FetchContent_MakeAvailable(yaml-cpp)
+
+include(cmake/cesium.cmake)
 
 # Erdblick Core Library
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,46 @@
+{
+    "version": 4,
+    "configurePresets": [
+        {
+            "name": "common",
+            "hidden": true,
+            "generator": "Ninja",
+            "binaryDir": "build",
+            "cacheVariables": {
+                "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+                "BUILD_SHARED_LIBS": "OFF"
+            }
+        },
+        {
+            "name": "debug",
+            "inherits": "common",
+            "displayName": "Debug",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Debug"
+            }
+        },
+        {
+            "name": "release",
+            "inherits": "common",
+            "displayName": "Release",
+            "cacheVariables": {
+                "CMAKE_BUILD_TYPE": "Release"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "debug",
+            "configurePreset": "debug",
+            "displayName": "Debug",
+            "environment": {
+                "NG_DEVELOP": "TRUE"
+            }
+        },
+        {
+            "name": "release",
+            "configurePreset": "release",
+            "displayName": "Release"
+        }
+    ]
+}

--- a/ci/10_linux_build.bash
+++ b/ci/10_linux_build.bash
@@ -7,11 +7,11 @@ source "$ci_dir/emsdk/emsdk_env.sh"
 cd "$ci_dir/.."
 
 export EMSCRIPTEN="$ci_dir/emsdk/upstream/emscripten"
-export PATH=$PATH:"$(pwd)/node_modules/.bin/"
+export PATH="$PATH:$(pwd)/node_modules/.bin/"
 
 rm -rf build && mkdir build
 cd build
 mkdir deps
 mkdir assets
 emcmake cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF ..
-cmake --build . -- -j
+cmake --build . -- -j"$(nproc)"

--- a/ci/10_linux_build.bash
+++ b/ci/10_linux_build.bash
@@ -9,9 +9,12 @@ cd "$ci_dir/.."
 export EMSCRIPTEN="$ci_dir/emsdk/upstream/emscripten"
 export PATH="$PATH:$(pwd)/node_modules/.bin/"
 
-rm -rf build && mkdir build
-cd build
-mkdir deps
-mkdir assets
-emcmake cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF ..
-cmake --build . -- -j"$(nproc)"
+rm -rf build
+mkdir -p build
+mkdir -p build/deps
+mkdir -p build/assets
+
+CMAKE_PRESET="${1:-release}"
+
+emcmake cmake --preset "$CMAKE_PRESET"
+cmake --build --preset "$CMAKE_PRESET" -- -j"$(nproc)"

--- a/ci/20_linux_rebuild.bash
+++ b/ci/20_linux_rebuild.bash
@@ -6,7 +6,10 @@ ci_dir="$(realpath ${BASH_SOURCE[0]} | xargs -I{} dirname {})"
 source "$ci_dir/emsdk/emsdk_env.sh"
 
 export EMSCRIPTEN="$ci_dir/emsdk/upstream/emscripten"
-export PATH=$PATH:"$ci_dir/../node_modules/.bin/"
+export PATH="$PATH:$ci_dir/../node_modules/.bin/"
 
-cd "$ci_dir/../build"
-cmake --build . -- -j"$(nproc)"
+cd "$ci_dir/.."
+
+CMAKE_PRESET="${1:-release}"
+
+cmake --build --preset "$CMAKE_PRESET" -- -j"$(nproc)"

--- a/ci/20_linux_rebuild.bash
+++ b/ci/20_linux_rebuild.bash
@@ -9,4 +9,4 @@ export EMSCRIPTEN="$ci_dir/emsdk/upstream/emscripten"
 export PATH=$PATH:"$ci_dir/../node_modules/.bin/"
 
 cd "$ci_dir/../build"
-cmake --build . -- -j
+cmake --build . -- -j"$(nproc)"

--- a/cmake/cesium.cmake
+++ b/cmake/cesium.cmake
@@ -1,0 +1,86 @@
+include(FetchContent)
+include(ExternalProject)
+
+block()
+
+if (NOT CMAKE_BUILD_TYPE)
+  message(FATAL_ERROR "Setting CMAKE_BUILD_TYPE is required!")
+endif()
+
+# List of cesium libs we want to expose as CMake targets
+set(CESIUM_LIBS
+  CesiumUtility
+  Cesium3DTilesWriter
+  CesiumGeospatial
+  CesiumGltf
+  CesiumGltfWriter)
+
+# Use fetch content for cloning the repository durring
+# configure phase. We do not call `FetchContent_MakeAvailable`,
+# but instead use `ExternalProject_Add` to compile Cesium in
+# isolation.
+FetchContent_Declare(cesiumnative_src
+  GIT_REPOSITORY "https://github.com/Klebert-Engineering/cesium-native.git"
+  GIT_TAG "main"
+  GIT_SUBMODULES_RECURSE YES
+  GIT_PROGRESS YES)
+
+FetchContent_GetProperties(cesiumnative_src)
+if (NOT cesiumnative_src_POPULATED)
+  FetchContent_Populate(cesiumnative_src)
+endif()
+
+# Cesium sets CMAKE_{DEBUG,RELEASE}_POSTFIX manually
+set(CMAKE_DEBUG_POSTFIX "d")
+set(CMAKE_RELEASE_POSTFIX "")
+
+# CMake uses some pre-, post- and suffix variables to decorate
+# library names with. We have to take them into account.
+if (${CMAKE_BUILD_TYPE} STREQUAL "Debug")
+  set(LIB_SUFFIX "${CMAKE_DEBUG_POSTFIX}${CMAKE_STATIC_LIBRARY_SUFFIX}")
+else()
+  set(LIB_SUFFIX "${CMAKE_RELEASE_POSTFIX}${CMAKE_STATIC_LIBRARY_SUFFIX}")
+endif()
+
+# Ninja generators _require_ a known list of byproducts.
+set(CESIUM_BYPRODUCTS "")
+foreach (lib ${CESIUM_LIBS})
+  list(APPEND CESIUM_BYPRODUCTS "<BINARY_DIR>/${lib}/${CMAKE_STATIC_LIBRARY_PREFIX}${lib}${LIB_SUFFIX}")
+endforeach()
+message(STATUS "cesium byproducts: ${CESIUM_BYPRODUCTS}")
+
+ExternalProject_Add(cesiumnative
+  SOURCE_DIR ${cesiumnative_src_SOURCE_DIR}
+  CMAKE_ARGS
+    -DCMAKE_CXX_FLAGS=${CMAKE_CXX_FLAGS}
+    -DCESIUM_TESTS_ENABLED=OFF
+    -DCESIUM_GLM_STRICT_ENABLED=OFF
+    -DCESIUM_TRACING_ENABLED=OFF
+    -DDRACO_JS_GLUE=OFF
+    -DBUILD_SHARED_LIBS=OFF
+    -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
+    -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+  BUILD_BYPRODUCTS
+    ${CESIUM_BYPRODUCTS}
+  INSTALL_COMMAND ""
+  STEP_TARGETS build
+  USES_TERMINAL_CONFIGURE TRUE
+  USES_TERMINAL_BUILD TRUE)
+
+function (add_cesium_lib TARGET)
+  ExternalProject_Get_Property(cesiumnative
+    SOURCE_DIR BINARY_DIR)
+  message(STATUS "Adding Cesium library: ${TARGET} (${BINARY_DIR}/${TARGET}/${CMAKE_STATIC_LIBRARY_PREFIX}${TARGET}${LIB_SUFFIX})")
+
+  add_library(${TARGET} STATIC IMPORTED)
+  set_target_properties(${TARGET} PROPERTIES
+    IMPORTED_LOCATION "${BINARY_DIR}/${TARGET}/${CMAKE_STATIC_LIBRARY_PREFIX}${TARGET}${LIB_SUFFIX}"
+    INTERFACE_INCLUDE_DIRECTORIES "${SOURCE_DIR}/${TARGET}/include")
+  add_dependencies(${TARGET} cesiumnative-build)
+endfunction()
+
+foreach (lib ${CESIUM_LIBS})
+  add_cesium_lib(${lib})
+endforeach()
+
+endblock()

--- a/libs/core/CMakeLists.txt
+++ b/libs/core/CMakeLists.txt
@@ -70,6 +70,7 @@ target_include_directories(erdblick-core
 
 target_link_libraries(erdblick-core
   PUBLIC
+    CesiumUtility
     Cesium3DTilesWriter
     CesiumGeospatial
     CesiumGltf


### PR DESCRIPTION
Allows building erdblick using Ninja. The solution to build cesium using CMakes `ExternalProject` instead of `FetchContent` is a fixed version taken from #64.

This PR also adds a `CMakePresets.json`, that defines a `release` and `debug` preset. The build script call those presets. Presets make it easy defining CMake options for certain build-types and/or changing the build options locally without having to touch the shell scripts.