### PR TITLE
Sourcedata switch layer

### DIFF
--- a/erdblick_app/app/highlight.pipe.ts
+++ b/erdblick_app/app/highlight.pipe.ts
@@ -9,7 +9,7 @@ export class HighlightSearch implements PipeTransform {
             return value;
         }
 
-        let re = new RegExp(String(args).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi');
+        const re = new RegExp(String(args).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi');
         return String(value).replace(re, '<mark>$&</mark>');
     }
 }

--- a/erdblick_app/app/inspection.panel.component.ts
+++ b/erdblick_app/app/inspection.panel.component.ts
@@ -55,7 +55,7 @@ interface InspectorTab {
         }`,
     ]
 })
-export class InspectionPanelComponent implements OnInit
+export class InspectionPanelComponent
 {
     title = "";
     tabs: InspectorTab[] = [];
@@ -85,8 +85,6 @@ export class InspectionPanelComponent implements OnInit
                 this.pushSourceDataInspector(selection);
         })
     }
-
-    ngOnInit(): void {}
 
     reset() {
         /* We always keep the first tab, which is a feature inspector. */

--- a/erdblick_app/app/inspection.panel.component.ts
+++ b/erdblick_app/app/inspection.panel.component.ts
@@ -115,7 +115,7 @@ export class InspectionPanelComponent
 
     pushSourceDataInspector(data: SelectedSourceData) {
         let tab = {
-            title: data.layerId,
+            title: SourceDataPanelComponent.layerNameForLayerId(data.layerId),
             icon: "pi-database",
             component: SourceDataPanelComponent,
             inputs: {

--- a/erdblick_app/app/inspection.service.ts
+++ b/erdblick_app/app/inspection.service.ts
@@ -32,7 +32,7 @@ export interface SelectedSourceData {
 export function selectedSourceDataEqualTo(a: SelectedSourceData | null, b: SelectedSourceData | null) {
     if (!a || !b)
         return false;
-    return (a == b || (a.mapId == b.mapId && a.tileId == b.tileId && a.layerId == b.layerId && a.address == b.address && a.featureId == b.featureId));
+    return (a === b || (a.mapId === b.mapId && a.tileId === b.tileId && a.layerId === b.layerId && a.address === b.address && a.featureId === b.featureId));
 }
 
 @Injectable({providedIn: 'root'})
@@ -174,16 +174,13 @@ export class InspectionService {
     async loadSourceDataLayer(tileId: number, layerId: string, mapId: string) : Promise<TileSourceDataLayer> {
         console.log(`Loading SourceDataLayer layerId=${layerId} tileId=${tileId}`);
 
-        let requests = [{
-            mapId: mapId,
-            layerId: layerId,
-            tileIds: [tileId]
-        }];
-
-        let tileParser = new coreLib.TileLayerParser();
-
-        let newRequestBody = JSON.stringify({
-            requests: requests
+        const tileParser = new coreLib.TileLayerParser();
+        const newRequestBody = JSON.stringify({
+            requests: [{
+                mapId: mapId,
+                layerId: layerId,
+                tileIds: [tileId]
+            }]
         });
 
         let layer: TileSourceDataLayer | undefined;

--- a/erdblick_app/app/map.panel.component.ts
+++ b/erdblick_app/app/map.panel.component.ts
@@ -40,7 +40,7 @@ import {Menu} from "primeng/menu";
                             {{ mapItem.key }}
                         </span>
                         <div *ngFor="let mapLayer of mapItem.value.layers | keyvalue: unordered">
-                            <div *ngIf="!mapLayer.value.layerId.startsWith('SourceData-')" class="flex-container">
+                            <div *ngIf="mapLayer.value.type != 'SourceData'" class="flex-container">
                                 <div class="font-bold white-space-nowrap"
                                     style="margin-left: 0.5em; display: flex; align-items: center;">
                                     <span class="material-icons" style="font-size: 1.5em; cursor: pointer"

--- a/erdblick_app/app/map.panel.component.ts
+++ b/erdblick_app/app/map.panel.component.ts
@@ -39,41 +39,43 @@ import {Menu} from "primeng/menu";
                         <span class="font-bold white-space-nowrap map-header">
                             {{ mapItem.key }}
                         </span>
-                        <div *ngFor="let mapLayer of mapItem.value.layers | keyvalue: unordered" class="flex-container">
-                            <div class="font-bold white-space-nowrap"
-                                 style="margin-left: 0.5em; display: flex; align-items: center;">
-                                <span class="material-icons" style="font-size: 1.5em; cursor: pointer"
-                                      (click)="showLayersToggleMenu($event, mapItem.key, mapLayer.key)">more_vert</span>
-                                <span>
-                                    <p-checkbox [(ngModel)]="mapLayer.value.visible"
-                                                (ngModelChange)="toggleLayer(mapItem.key, mapLayer.key)"
-                                                [label]="mapLayer.key" [binary]="true"/>
-                                </span>
+                        <div *ngFor="let mapLayer of mapItem.value.layers | keyvalue: unordered">
+                            <div *ngIf="!mapLayer.value.layerId.startsWith('SourceData-')" class="flex-container">
+                                <div class="font-bold white-space-nowrap"
+                                    style="margin-left: 0.5em; display: flex; align-items: center;">
+                                    <span class="material-icons" style="font-size: 1.5em; cursor: pointer"
+                                        (click)="showLayersToggleMenu($event, mapItem.key, mapLayer.key)">more_vert</span>
+                                    <span>
+                                        <p-checkbox [(ngModel)]="mapLayer.value.visible"
+                                                    (ngModelChange)="toggleLayer(mapItem.key, mapLayer.key)"
+                                                    [label]="mapLayer.key" [binary]="true"/>
+                                    </span>
+                                </div>
+                                <div class="layer-controls">
+                                    <p-button (click)="toggleTileBorders(mapItem.key, mapLayer.key)"
+                                            label="" pTooltip="Toggle tile borders" tooltipPosition="bottom"
+                                            [style]="{'padding-left': '0', 'padding-right': '0'}">
+                                        <span class="material-icons"
+                                            style="font-size: 1.2em; margin: 0 auto;">{{ mapLayer.value.tileBorders ? 'select_all' : 'deselect' }}</span>
+                                    </p-button>
+                                    <p-button *ngIf="mapLayer.value.coverage.length"
+                                            (click)="focus(mapLayer.value.coverage[0], $event)"
+                                            label="" pTooltip="Focus on layer" tooltipPosition="bottom"
+                                            [style]="{'padding-left': '0', 'padding-right': '0'}">
+                                        <span class="material-icons" style="font-size: 1.2em; margin: 0 auto;">loupe</span>
+                                    </p-button>
+                                    <p-inputNumber [(ngModel)]="mapLayer.value.level"
+                                                (ngModelChange)="onLayerLevelChanged($event, mapItem.key, mapLayer.key)"
+                                                [showButtons]="true" [min]="0" [max]="15"
+                                                buttonLayout="horizontal" spinnerMode="horizontal" inputId="horizontal"
+                                                decrementButtonClass="p-button-secondary"
+                                                incrementButtonClass="p-button-secondary"
+                                                incrementButtonIcon="pi pi-plus" decrementButtonIcon="pi pi-minus"
+                                                pTooltip="Change zoom level" tooltipPosition="bottom">
+                                    </p-inputNumber>
+                                </div>
+                                <input class="level-indicator" type="text" pInputText [disabled]="true" [(ngModel)]="mapLayer.value.level" />
                             </div>
-                            <div class="layer-controls">
-                                <p-button (click)="toggleTileBorders(mapItem.key, mapLayer.key)"
-                                          label="" pTooltip="Toggle tile borders" tooltipPosition="bottom"
-                                          [style]="{'padding-left': '0', 'padding-right': '0'}">
-                                    <span class="material-icons"
-                                          style="font-size: 1.2em; margin: 0 auto;">{{ mapLayer.value.tileBorders ? 'select_all' : 'deselect' }}</span>
-                                </p-button>
-                                <p-button *ngIf="mapLayer.value.coverage.length"
-                                          (click)="focus(mapLayer.value.coverage[0], $event)"
-                                          label="" pTooltip="Focus on layer" tooltipPosition="bottom"
-                                          [style]="{'padding-left': '0', 'padding-right': '0'}">
-                                    <span class="material-icons" style="font-size: 1.2em; margin: 0 auto;">loupe</span>
-                                </p-button>
-                                <p-inputNumber [(ngModel)]="mapLayer.value.level"
-                                               (ngModelChange)="onLayerLevelChanged($event, mapItem.key, mapLayer.key)"
-                                               [showButtons]="true" [min]="0" [max]="15"
-                                               buttonLayout="horizontal" spinnerMode="horizontal" inputId="horizontal"
-                                               decrementButtonClass="p-button-secondary"
-                                               incrementButtonClass="p-button-secondary"
-                                               incrementButtonIcon="pi pi-plus" decrementButtonIcon="pi pi-minus"
-                                               pTooltip="Change zoom level" tooltipPosition="bottom">
-                                </p-inputNumber>
-                            </div>
-                            <input class="level-indicator" type="text" pInputText [disabled]="true" [(ngModel)]="mapLayer.value.level" />
                         </div>
                     </div>
                 </div>

--- a/erdblick_app/app/map.service.ts
+++ b/erdblick_app/app/map.service.ts
@@ -265,10 +265,6 @@ export class MapService {
                     let maps = new Map<string, MapInfoItem>(result.filter(m => !m.addOn).map(mapInfo => {
                         let layers = new Map<string, LayerInfoItem>();
                         for (let [layerId, layerInfo] of Object.entries(mapInfo.layers)) {
-                            // Filter out source-data layers
-                            if (layerId.startsWith("SourceData-"))
-                                continue;
-
                             [layerInfo.visible, layerInfo.level, layerInfo.tileBorders] = this.parameterService.mapLayerConfig(mapInfo.mapId, layerId, 13);
                             mapLayerLevels.push([
                                 mapInfo.mapId + '/' + layerId,

--- a/erdblick_app/app/map.service.ts
+++ b/erdblick_app/app/map.service.ts
@@ -22,7 +22,7 @@ export interface LayerInfoItem extends Object {
     coverage: Array<number|CoverageRectItem>;
     featureTypes: Array<{name: string, uniqueIdCompositions: Array<Object>}>;
     layerId: string;
-    type: number;
+    type: string;
     version: {major: number, minor: number, patch: number};
     zoomLevels: Array<number>;
     level: number;
@@ -295,7 +295,7 @@ export class MapService {
 
         const layer = mapItem.layers.get(layerId);
         if (layer) {
-            if (layer.type == coreLib.LayerType.SOURCEDATA.value)
+            if (layer.type == "SourceData")
                 return false;
             return layer.visible;
         }

--- a/erdblick_app/app/parameters.service.ts
+++ b/erdblick_app/app/parameters.service.ts
@@ -167,7 +167,7 @@ export class ParametersService {
             }
         });
 
-    constructor(public router: Router /*, private inspectionService: InspectionService*/) {
+    constructor(public router: Router) {
         let parameters = this.loadSavedParameters();
         this.parameters = new BehaviorSubject<ErdblickParameters>(parameters!);
         this.saveParameters();

--- a/erdblick_app/app/sourcedata.panel.component.ts
+++ b/erdblick_app/app/sourcedata.panel.component.ts
@@ -115,7 +115,7 @@ export class SourceDataPanelComponent implements OnInit {
     ngOnInit(): void {
         this.inspectionService.loadSourceDataLayer(this.sourceData.tileId, this.sourceData.layerId, this.sourceData.mapId)
             .then(layer => {
-                let root = layer.toObject()
+                const root = layer.toObject()
                 this.addressFormat = layer.addressFormat();
 
                 layer.delete();
@@ -170,7 +170,7 @@ export class SourceDataPanelComponent implements OnInit {
         this.treeData = [];
         this.errorMessage = message;
 
-        console.error(this.errorMessage);
+        console.error("Error while processing SourceData tree:", this.errorMessage)
     }
 
     /**
@@ -187,23 +187,19 @@ export class SourceDataPanelComponent implements OnInit {
 
         const prefix = "https://developer.nds.live/schema/";
 
-        let match = schema.match(/^nds\.(([^.]+\.)+)v(\d{4}_\d{2})((\.[^.]*)+)/);
+        const match = schema.match(/^nds\.(([^.]+\.)+)v(\d{4}_\d{2})((\.[^.]*)+)/);
         if (!match || match.length <= 4)
             return schema;
 
         // Sub-namespaces in front of the version get joined by "-". Names past the version get joined by "/"
-        let url =
+        const url =
             match[1].replace(/^(.*)\.$/, "$1/").replaceAll(".", "-") +
             match[3].replaceAll("_", ".") +
             match[4].replaceAll(".", "/");
         return `<a href="${prefix + url}" target="_blank">${schema}</a>`;
     }
 
-    addressFormatter(address?: any) {
-        if (!address) {
-            return address;
-        }
-
+    addressFormatter(address?: any): string {
         if (typeof address === 'object') {
             return `${address.offset}:${address.size}`
         } else {
@@ -212,10 +208,9 @@ export class SourceDataPanelComponent implements OnInit {
     }
 
     selectItemWithAddress(address: bigint) {
-        let searchAddress: any = address;
         let addressInRange: any;
         if (this.addressFormat == coreLib.SourceDataAddressFormat.BIT_RANGE) {
-            searchAddress = {
+            const searchAddress = {
                 offset: address >> BigInt(32) & BigInt(0xFFFFFFFF),
                 size: address & BigInt(0xFFFFFFFF),
             }
@@ -223,12 +218,15 @@ export class SourceDataPanelComponent implements OnInit {
             const addressLow = typeof searchAddress === 'object' ? searchAddress['offset'] : searchAddress;
             const addressHigh = addressLow + (typeof searchAddress === 'object' ? searchAddress['size'] : searchAddress);
 
-            addressInRange = (addr: any) => {
-                return addr.offset >= addressLow && addr.offset + addr.size <= addressHigh && (addr.size != 0 || addressLow == addressHigh);
+            addressInRange = (address: any) => {
+                return address.offset >= addressLow &&
+                    address.offset + address.size <= addressHigh &&
+                    (address.size != 0 || addressLow == addressHigh);
             }
         } else {
-            addressInRange = (addr: any) => {
-                return addr == searchAddress;
+            const searchAddress = address;
+            addressInRange = (address: any) => {
+                return address == searchAddress;
             }
         }
 
@@ -244,8 +242,7 @@ export class SourceDataPanelComponent implements OnInit {
                 node.data.styleClass = "highlight";
             }
 
-            const address = node.data.address;
-            if (address && addressInRange(address)) {
+            if (node.data.address && addressInRange(node.data.address)) {
                 highlight = true;
 
                 if (!firstHighlightedItemIndex)
@@ -262,7 +259,6 @@ export class SourceDataPanelComponent implements OnInit {
             }
         };
 
-        console.log(`Highlighting item with address`, searchAddress);
         this.treeData.forEach((item: TreeTableNode, index) => {
             select(item, [], false, index);
         });

--- a/erdblick_app/app/sourcedata.panel.component.ts
+++ b/erdblick_app/app/sourcedata.panel.component.ts
@@ -154,7 +154,7 @@ export class SourceDataPanelComponent implements OnInit {
                     {
                         label: "Switch Layer",
                         items: Array.from(map.layers.values())
-                            .filter(item => item.layerId.startsWith("SourceData-"))
+                            .filter(item => item.type == "SourceData")
                             .map(item => {
                                 return {
                                     label: SourceDataPanelComponent.layerNameForLayerId(item.layerId),

--- a/erdblick_app/app/sourcedata.panel.component.ts
+++ b/erdblick_app/app/sourcedata.panel.component.ts
@@ -219,8 +219,10 @@ export class SourceDataPanelComponent implements OnInit {
     addressFormatter(address?: any): string {
         if (typeof address === 'object') {
             return `${address.offset}:${address.size}`
-        } else {
+        } else if (address) {
             return `${address}`
+        } else {
+            return '';
         }
     }
 

--- a/erdblick_app/app/treetablefilter-patch.directive.ts
+++ b/erdblick_app/app/treetablefilter-patch.directive.ts
@@ -25,11 +25,11 @@ export class TreeTableFilterPatchDirective implements AfterContentInit {
             if (node) {
                 let matched = false;
                 if (node.children) {
-                    let childNodes = [...node.children].map(node => { return { ...node }; });
+                    const children = node.children.map(node => { return { ...node }; });
                     node.children = [];
 
                     let hadMatchingLeaf = false;
-                    for (let childNode of childNodes) {
+                    for (const childNode of children) {
                         if (this.tt.isFilterMatched(childNode, paramsWithoutNode)) {
                             matched = true;
                             hadMatchingLeaf = hadMatchingLeaf || this.tt.isNodeLeaf(childNode);
@@ -41,7 +41,7 @@ export class TreeTableFilterPatchDirective implements AfterContentInit {
                     // If we had a matching leaf node, add all leaf nodes.
                     // Since we are in strict mode, if no child matched, add all
                     if (hadMatchingLeaf || !matched) {
-                        node.children = childNodes;
+                        node.children = children;
                     }
                 }
 

--- a/erdblick_app/styles.scss
+++ b/erdblick_app/styles.scss
@@ -129,6 +129,14 @@ body {
 
     .filter-container {
         width: 100%;
+        display: flex;
+        gap: 4px;
+        justify-content: center;
+
+        .p-button {
+            width: 32px;
+            height: 32px;
+        }
     }
 
     .filter-input {

--- a/libs/core/CMakeLists.txt
+++ b/libs/core/CMakeLists.txt
@@ -13,6 +13,7 @@ set(ERDBLICK_SOURCE_FILES
   include/erdblick/geometry.h
   include/erdblick/inspection.h
   include/erdblick/search.h
+  include/erdblick/sourcedata.hpp
 
   include/erdblick/cesium-interface/object.h
   include/erdblick/cesium-interface/primitive.h
@@ -31,6 +32,7 @@ set(ERDBLICK_SOURCE_FILES
   src/geometry.cpp
   src/inspection.cpp
   src/search.cpp
+  src/sourcedata.cpp
 
   src/cesium-interface/object.cpp
   src/cesium-interface/primitive.cpp
@@ -40,10 +42,7 @@ set(ERDBLICK_SOURCE_FILES
 )
 
 if(${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")
-  list(APPEND ERDBLICK_SOURCE_FILES
-    src/bindings.cpp
-    src/sourcedata.hpp
-    src/sourcedata.cpp)
+  list(APPEND ERDBLICK_SOURCE_FILES src/bindings.cpp)
   add_executable(erdblick-core ${ERDBLICK_SOURCE_FILES})
   target_compile_definitions(erdblick-core PUBLIC EMSCRIPTEN)
   # target_compile_options(erdblick-core PRIVATE -fwasm-exceptions)

--- a/libs/core/include/erdblick/cesium-interface/object.h
+++ b/libs/core/include/erdblick/cesium-interface/object.h
@@ -201,7 +201,7 @@ ReturnType JsValue::call(std::string const& methodName, Args... args)
     // Record the method call in the mock object
     value_["methodCalls"].push_back({
         {"methodName", methodName},
-        {"arguments", {args...}} // This assumes Args are convertible to nlohmann::json
+        {"arguments", {UnpackNativeValue(args)...}} // This assumes Args are convertible to nlohmann::json
     });
     return ReturnType(); // default-constructed value
 #endif

--- a/libs/core/include/erdblick/sourcedata.hpp
+++ b/libs/core/include/erdblick/sourcedata.hpp
@@ -1,0 +1,6 @@
+#include <emscripten/bind.h>
+
+#include "mapget/model/sourcedatalayer.h"
+#include "cesium-interface/object.h"
+
+erdblick::JsValue tileSourceDataLayerToObject(const mapget::TileSourceDataLayer& layer);

--- a/libs/core/include/erdblick/sourcedata.hpp
+++ b/libs/core/include/erdblick/sourcedata.hpp
@@ -3,4 +3,17 @@
 #include "mapget/model/sourcedatalayer.h"
 #include "cesium-interface/object.h"
 
+namespace erdblick
+{
+
+/**
+ * Convert a SourceDataLayar hierarchy to a tree model compatible
+ * structure.
+ *
+ * Layout:
+ *   [{ data: [{key: "...", value: ...}, ...], children: [{ ... }] }, ...]
+ *
+ **/
 erdblick::JsValue tileSourceDataLayerToObject(const mapget::TileSourceDataLayer& layer);
+
+}

--- a/libs/core/src/bindings.cpp
+++ b/libs/core/src/bindings.cpp
@@ -5,6 +5,7 @@
 #include "buffer.h"
 #include "cesium-interface/object.h"
 #include "mapget/model/info.h"
+#include "mapget/model/sourcedatalayer.h"
 #include "simfil/model/nodes.h"
 #include "visualization.h"
 #include "parser.h"
@@ -248,10 +249,12 @@ EMSCRIPTEN_BINDINGS(erdblick)
     em::class_<FeatureLayerStyle>("FeatureLayerStyle").constructor<SharedUint8Array&>()
         .function("options", &FeatureLayerStyle::options, em::allow_raw_pointers());
 
+    ////////// SourceDataAddressFormat
     em::enum_<mapget::TileSourceDataLayer::SourceDataAddressFormat>("SourceDataAddressFormat")
         .value("UNKNOWN", mapget::TileSourceDataLayer::SourceDataAddressFormat::Unknown)
         .value("BIT_RANGE", mapget::TileSourceDataLayer::SourceDataAddressFormat::BitRange);
 
+    ////////// TileSourceDataLayer
     em::class_<mapget::TileSourceDataLayer>("TileSourceDataLayer")
         .smart_ptr<std::shared_ptr<mapget::TileSourceDataLayer>>(
             "std::shared_ptr<mapget::TileSourceDataLayer>")
@@ -264,7 +267,9 @@ EMSCRIPTEN_BINDINGS(erdblick)
                 return self.toJson().dump(2);
             }))
         .function(
-            "toObject", &tileSourceDataLayerToObject);
+            "toObject", std::function<em::val(const mapget::TileSourceDataLayer&)>([](const mapget::TileSourceDataLayer& self) {
+                return *tileSourceDataLayerToObject(self);
+            }));
 
     ////////// Feature
     using FeaturePtr = mapget::model_ptr<mapget::Feature>;

--- a/libs/core/src/sourcedata.cpp
+++ b/libs/core/src/sourcedata.cpp
@@ -3,14 +3,9 @@
 #include "mapget/model/sourcedatalayer.h"
 #include "mapget/model/sourcedata.h"
 
-/**
- * Convert a SourceDataLayar hierarchy to a tree model compatible
- * structure.
- *
- * Layout:
- *   [{ data: [{key: "...", value: ...}, ...], children: [{ ... }] }, ...]
- *
- **/
+namespace erdblick
+{
+
 erdblick::JsValue tileSourceDataLayerToObject(const mapget::TileSourceDataLayer& layer) {
     using namespace erdblick;
     using namespace mapget;
@@ -125,4 +120,6 @@ erdblick::JsValue tileSourceDataLayerToObject(const mapget::TileSourceDataLayer&
         return JsValue::Dict();
 
     return visit(JsValue("root"), *layer.root(0));
+}
+
 }

--- a/libs/core/src/sourcedata.hpp
+++ b/libs/core/src/sourcedata.hpp
@@ -1,5 +1,0 @@
-#include <emscripten/bind.h>
-
-#include "mapget/model/sourcedatalayer.h"
-
-emscripten::val tileSourceDataLayerToObject(const mapget::TileSourceDataLayer& layer);


### PR DESCRIPTION
This PR adds a burger-menu to switch between the available source-data layers.
The currently inspected layer is disabled.

I've added the PR-Review fixes of #15 to this PR.

![grafik](https://github.com/user-attachments/assets/40ee6cc8-46e0-45e8-9541-84be7826bb08)

