### PR TITLE
Feature Inspector Feature Source-Data + UI Fixes

### DIFF
--- a/erdblick_app/app/feature.panel.component.ts
+++ b/erdblick_app/app/feature.panel.component.ts
@@ -230,7 +230,7 @@ export class FeaturePanelComponent implements OnInit  {
     expandTreeNodes(nodes: TreeTableNode[], parent: any = null): void {
         nodes.forEach(node => {
             const isTopLevelNode = parent === null;
-            const isSection = node.data["type"] === this.InspectionValueType.SECTION.value;
+            const isSection = node.data && node.data["type"] === this.InspectionValueType.SECTION.value;
             const hasSingleChild = node.children && node.children.length === 1;
             node.expanded = isTopLevelNode || isSection || hasSingleChild;
 

--- a/erdblick_app/app/feature.panel.component.ts
+++ b/erdblick_app/app/feature.panel.component.ts
@@ -79,8 +79,7 @@ interface Column {
                                     />
                                     <ng-template ngFor let-item [ngForOf]="rowData.sourceDataReferences">
                                         <p-button
-                                            (click)="showSourceData(item)"
-
+                                            (click)="showSourceData($event, item)"
                                             [rounded]="true"
                                             severity="secondary"
                                             label="{{ item.qualifier.substring(0, 1).toUpperCase() }}"
@@ -342,7 +341,9 @@ export class FeaturePanelComponent implements OnInit  {
         }
     }
 
-    showSourceData(sourceDataRef: any) {
+    showSourceData(event: any, sourceDataRef: any) {
+        event.stopPropagation();
+
         const layerId = sourceDataRef.layerId;
         const tileId = sourceDataRef.tileId;
         const address = sourceDataRef.address;

--- a/erdblick_app/app/feature.panel.component.ts
+++ b/erdblick_app/app/feature.panel.component.ts
@@ -230,8 +230,9 @@ export class FeaturePanelComponent implements OnInit  {
     expandTreeNodes(nodes: TreeTableNode[], parent: any = null): void {
         nodes.forEach(node => {
             const isTopLevelNode = parent === null;
+            const isSection = node.data["type"] === this.InspectionValueType.SECTION.value;
             const hasSingleChild = node.children && node.children.length === 1;
-            node.expanded = isTopLevelNode || hasSingleChild;
+            node.expanded = isTopLevelNode || isSection || hasSingleChild;
 
             if (node.children) {
                 this.expandTreeNodes(node.children, node);

--- a/erdblick_app/app/inspection.panel.component.ts
+++ b/erdblick_app/app/inspection.panel.component.ts
@@ -81,8 +81,10 @@ export class InspectionPanelComponent
         });
 
         this.inspectionService.selectedSourceData.pipe(distinctUntilChanged(selectedSourceDataEqualTo)).subscribe(selection => {
-            if (selection)
+            if (selection) {
+                this.reset();
                 this.pushSourceDataInspector(selection);
+            }
         })
     }
 

--- a/erdblick_app/app/inspection.service.ts
+++ b/erdblick_app/app/inspection.service.ts
@@ -148,6 +148,9 @@ export class InspectionService {
                 if (section.hasOwnProperty("info")) {
                     node.data["info"] = section.info;
                 }
+                if (section.hasOwnProperty("sourceDataReferences")) {
+                    node.data["sourceDataReferences"] = section.sourceDataReferences;
+                }
                 node.children = convertToTreeTableNodes(section.children);
                 treeNodes.push(node);
             }

--- a/libs/core/src/inspection.cpp
+++ b/libs/core/src/inspection.cpp
@@ -46,6 +46,10 @@ JsValue InspectionConverter::convert(model_ptr<Feature> const& featurePtr)
     stringPool_ = featurePtr->model().strings();
     featureId_ = featurePtr->id()->toString();
 
+    // Top-Level Feature Item
+    auto featureScope = push("Feature", "", ValueType::Section);
+    featureScope->value_ = JsValue(featurePtr->id()->toString());
+    convertSourceDataReferences(featurePtr->sourceDataReferences(), *featureScope);
     // Identifiers section.
     {
         auto scope = push(convertStringView("Identifiers"), "", ValueType::Section);

--- a/libs/core/src/inspection.cpp
+++ b/libs/core/src/inspection.cpp
@@ -50,6 +50,7 @@ JsValue InspectionConverter::convert(model_ptr<Feature> const& featurePtr)
     auto featureScope = push("Feature", "", ValueType::Section);
     featureScope->value_ = JsValue(featurePtr->id()->toString());
     convertSourceDataReferences(featurePtr->sourceDataReferences(), *featureScope);
+
     // Identifiers section.
     {
         auto scope = push(convertStringView("Identifiers"), "", ValueType::Section);


### PR DESCRIPTION
The Feature itself now gets inserted as a top-level tree item.
This allows for the feature itself to have a list of go-to source-data  buttons.

Bugs Fixed:
- Opening the Source-Data inspector could collapse the source tree node
- You could open multiple Source-Data inspectors by switching layers