### PR TITLE
Automatic Public Path Detection

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,4 +16,7 @@ module.exports = {
     externals: {
         'cesium': 'Cesium'
     },
+    output: {
+        publicPath: 'auto'
+    }
 };


### PR DESCRIPTION
This change should allow webpack to automatically determine the public app path. See https://webpack.js.org/guides/public-path/#automatic-publicpath