### PR TITLE
 Reduce max loaded tiles default value to improve responsiveness

### DIFF
--- a/erdblick_app/app/parameters.service.ts
+++ b/erdblick_app/app/parameters.service.ts
@@ -4,7 +4,7 @@ import {Cartesian3, Cartographic, CesiumMath, Camera} from "./cesium";
 import {Params, Router} from "@angular/router";
 import {SelectedSourceData} from "./inspection.service";
 
-export const MAX_NUM_TILES_TO_LOAD = 2048;
+export const MAX_NUM_TILES_TO_LOAD = 512;
 export const MAX_NUM_TILES_TO_VISUALIZE = 512;
 
 /**


### PR DESCRIPTION
This reduces the general load which is especially useful to improve repsonsiveness when dealing with slow data sources or big amount of data. A dedicated optimization is needed to improve the situation in a sustainable way - this PR intends to help users in the shortterm. 