### PR TITLE
Inspect All SourceDataLayers of a Tile

### DIFF
--- a/erdblick_app/app/inspection.panel.component.ts
+++ b/erdblick_app/app/inspection.panel.component.ts
@@ -115,7 +115,7 @@ export class InspectionPanelComponent
                 if (map) {
                     this.layerMenuItems = Array.from(map.layers.values()).filter(item => item.type == "SourceData").map(item => {
                         return {
-                            label: SourceDataPanelComponent.layerNameForLayerId(item.layerId),
+                            label: this.inspectionService.layerNameForLayerId(item.layerId),
                             disabled: item.layerId === selection.layerId,
                             command: () => {
                                 let sourceData = {...selection};

--- a/erdblick_app/app/inspection.panel.component.ts
+++ b/erdblick_app/app/inspection.panel.component.ts
@@ -115,7 +115,7 @@ export class InspectionPanelComponent
                 if (map) {
                     this.layerMenuItems = Array.from(map.layers.values()).filter(item => item.type == "SourceData").map(item => {
                         return {
-                            label: this.inspectionService.layerNameForLayerId(item.layerId),
+                            label: this.inspectionService.layerNameForSourceDataLayerId(item.layerId),
                             disabled: item.layerId === selection.layerId,
                             command: () => {
                                 let sourceData = {...selection};

--- a/erdblick_app/app/inspection.service.ts
+++ b/erdblick_app/app/inspection.service.ts
@@ -317,6 +317,39 @@ export class InspectionService {
         });
     }
 
+    /**
+     * Returns a human-readable layer name for a layer id.
+     *
+     * @param layerId Layer id to get the name for
+     */
+    layerNameForLayerId(layerId: string) {
+        const match = layerId.match(/^SourceData-([^.]+\.)*(.*)-([\d]+)/);
+        if (match)
+            return `${match[2]}.${match[3]}`;
+        return layerId;
+    }
+
+    /**
+     * Returns an internal layerId for a human-readable layer name.
+     *
+     * @param layerId Layer id to get the name for
+     */
+    layerIdForLayerName(layerName: string) {
+        for (const [_, mapInfo] of this.mapService.maps.getValue().entries()) {
+            for (const [_, layerInfo] of mapInfo.layers.entries()) {
+                if (layerInfo.type == "SourceData") {
+                    console.log(layerInfo.layerId, this.layerNameForLayerId(layerInfo.layerId), layerName)
+                    if (this.layerNameForLayerId(layerInfo.layerId) == layerName ||
+                        this.layerNameForLayerId(layerInfo.layerId) == layerName.replace('-', '.') ||
+                        layerInfo.layerId == layerName) {
+                        return layerInfo.layerId;
+                    }
+                }
+            }
+        }
+        return null;
+    }
+
     protected readonly InspectionValueType = coreLib.ValueType;
     protected readonly GeometryType = coreLib.GeomType;
 }

--- a/erdblick_app/app/inspection.service.ts
+++ b/erdblick_app/app/inspection.service.ts
@@ -322,7 +322,7 @@ export class InspectionService {
      *
      * @param layerId Layer id to get the name for
      */
-    layerNameForLayerId(layerId: string) {
+    layerNameForSourceDataLayerId(layerId: string) {
         const match = layerId.match(/^SourceData-([^.]+\.)*(.*)-([\d]+)/);
         if (match)
             return `${match[2]}.${match[3]}`;
@@ -334,13 +334,13 @@ export class InspectionService {
      *
      * @param layerId Layer id to get the name for
      */
-    layerIdForLayerName(layerName: string) {
+    sourceDataLayerIdForLayerName(layerName: string) {
         for (const [_, mapInfo] of this.mapService.maps.getValue().entries()) {
             for (const [_, layerInfo] of mapInfo.layers.entries()) {
                 if (layerInfo.type == "SourceData") {
-                    console.log(layerInfo.layerId, this.layerNameForLayerId(layerInfo.layerId), layerName)
-                    if (this.layerNameForLayerId(layerInfo.layerId) == layerName ||
-                        this.layerNameForLayerId(layerInfo.layerId) == layerName.replace('-', '.') ||
+                    console.log(layerInfo.layerId, this.layerNameForSourceDataLayerId(layerInfo.layerId), layerName)
+                    if (this.layerNameForSourceDataLayerId(layerInfo.layerId) == layerName ||
+                        this.layerNameForSourceDataLayerId(layerInfo.layerId) == layerName.replace('-', '.') ||
                         layerInfo.layerId == layerName) {
                         return layerInfo.layerId;
                     }

--- a/erdblick_app/app/inspection.service.ts
+++ b/erdblick_app/app/inspection.service.ts
@@ -260,8 +260,6 @@ export class InspectionService {
     }
 
     async loadSourceDataLayer(tileId: number, layerId: string, mapId: string) : Promise<TileSourceDataLayer> {
-        console.log(`Loading SourceDataLayer layerId=${layerId} tileId=${tileId}`);
-
         const tileParser = new coreLib.TileLayerParser();
         const newRequestBody = JSON.stringify({
             requests: [{
@@ -338,7 +336,6 @@ export class InspectionService {
         for (const [_, mapInfo] of this.mapService.maps.getValue().entries()) {
             for (const [_, layerInfo] of mapInfo.layers.entries()) {
                 if (layerInfo.type == "SourceData") {
-                    console.log(layerInfo.layerId, this.layerNameForSourceDataLayerId(layerInfo.layerId), layerName)
                     if (this.layerNameForSourceDataLayerId(layerInfo.layerId) == layerName ||
                         this.layerNameForSourceDataLayerId(layerInfo.layerId) == layerName.replace('-', '.') ||
                         layerInfo.layerId == layerName) {

--- a/erdblick_app/app/jump.service.ts
+++ b/erdblick_app/app/jump.service.ts
@@ -167,8 +167,6 @@ export class JumpTargetService {
                 return null;
             }
 
-
-
             return [tileId, mapId, sourceLayerId]
         }
 
@@ -246,9 +244,6 @@ export class JumpTargetService {
                     label: label,
                     enabled: !fjt.error,
                     execute: (_: string) => {
-                        if (fjt.name.toLowerCase().includes("tileid")) {
-
-                        }
                         this.highlightByJumpTarget(fjt).then();
                     },
                     validate: (_: string) => { return !fjt.error; },

--- a/erdblick_app/app/jump.service.ts
+++ b/erdblick_app/app/jump.service.ts
@@ -148,7 +148,7 @@ export class JumpTargetService {
                 try {
                     tileId = BigInt(bigintStr);
                 } catch {
-                    valid = false;
+                    return null;
                 }
 
                 if (quoted1 || unquoted1) {
@@ -170,10 +170,10 @@ export class JumpTargetService {
                     }
                 }
             } else {
-                valid = false;
+                return null;
             }
 
-            if (tileId === -1n || !valid) {
+            if (tileId === -1n) {
                 return null;
             }
 
@@ -216,6 +216,9 @@ export class JumpTargetService {
 
             valid &&= this.validateMapgetTileId(matches[0].toString());
         }
+        else {
+            valid = false;
+        }
 
         return {
             icon: "pi-database",
@@ -253,7 +256,7 @@ export class JumpTargetService {
                     }
                 }
             },
-            validate: (value: string) => {
+            validate: (_: string) => {
                 return valid;
             }
         }

--- a/erdblick_app/app/map.service.ts
+++ b/erdblick_app/app/map.service.ts
@@ -97,7 +97,6 @@ export class MapService {
     private tileVisualizationQueue: [string, TileVisualization][];
     private selectionVisualizations: TileVisualization[];
     private hoverVisualizations: TileVisualization[];
-    private specialTileBorderColourForTiles: [bigint, Color] = [-1n, Color.TRANSPARENT];
 
     tileParser: TileLayerParser|null = null;
     tileVisualizationTopic: Subject<any>;
@@ -446,10 +445,6 @@ export class MapService {
                     return false;
                 }
                 tileVisu.showTileBorder = this.getMapLayerBorderState(mapName, layerName);
-                if (this.specialTileBorderColourForTiles[0] == tileVisu.tile.tileId) {
-                    tileVisu.showTileBorder = true;
-                    tileVisu.specialBorderColour = this.specialTileBorderColourForTiles[1];
-                }
                 tileVisu.isHighDetail = this.currentHighDetailTileIds.has(tileVisu.tile.tileId) || tileVisu.tile.preventCulling;
                 return true;
             });
@@ -856,10 +851,5 @@ export class MapService {
                 visualizationCollection.push(visu);
             }
         }
-    }
-
-    setSpecialTileBorder(tileId: bigint, color: Color) {
-        this.specialTileBorderColourForTiles = [tileId, color];
-        this.update();
     }
 }

--- a/erdblick_app/app/map.service.ts
+++ b/erdblick_app/app/map.service.ts
@@ -809,6 +809,14 @@ export class MapService {
         this.zoomLevel.next(MAX_ZOOM_LEVEL);
     }
 
+    *tileLayersForTileId(tileId: bigint): Generator<FeatureTile> {
+        for (const tile of this.loadedTileLayers.values()) {
+            if (tile.tileId == tileId) {
+                yield tile;
+            }
+        }
+    }
+
     private visualizeHighlights(mode: HighlightMode, featureWrappers: Array<FeatureWrapper>) {
         let visualizationCollection = null;
         switch (mode) {

--- a/erdblick_app/app/parameters.service.ts
+++ b/erdblick_app/app/parameters.service.ts
@@ -499,10 +499,11 @@ export class ParametersService {
                 this.saveHistoryStateValue(value);
             }
         }
+        console.log(value);
         this.p().search = value ? value : [];
         this._replaceUrl = false;
-        this.parameters.next(this.p())
         this.lastSearchHistoryEntry.next(value);
+        this.parameters.next(this.p())
     }
 
     private saveHistoryStateValue(value: [number, string]) {

--- a/erdblick_app/app/parameters.service.ts
+++ b/erdblick_app/app/parameters.service.ts
@@ -449,6 +449,7 @@ export class ParametersService {
 
     resetStorage() {
         localStorage.removeItem('erdblickParameters');
+        localStorage.removeItem('searchHistory');
         window.location.href = this.router.url.split('?')[0];
     }
 
@@ -499,7 +500,6 @@ export class ParametersService {
                 this.saveHistoryStateValue(value);
             }
         }
-        console.log(value);
         this.p().search = value ? value : [];
         this._replaceUrl = false;
         this.lastSearchHistoryEntry.next(value);

--- a/erdblick_app/app/preferences.component.ts
+++ b/erdblick_app/app/preferences.component.ts
@@ -44,7 +44,7 @@ import {MAX_NUM_TILES_TO_LOAD, MAX_NUM_TILES_TO_VISUALIZE, ParametersService} fr
             <p-button (click)="applyTileLimits()" label="Apply" icon="pi pi-check"></p-button>
             <p-divider></p-divider>
             <div class="button-container">
-                <label>Storage for Viewer properties (URL):</label>
+                <label>Storage for Viewer properties and search history:</label>
                 <p-button (click)="clearURLProperties()" label="Clear" icon="pi pi-trash"></p-button>
             </div>
             <div class="button-container">

--- a/erdblick_app/app/rightclickmenu.service.ts
+++ b/erdblick_app/app/rightclickmenu.service.ts
@@ -18,7 +18,7 @@ export class RightClickMenuService {
     lastInspectedTileSourceDataOption: BehaviorSubject<{tileId: number, mapId: string, layerId: string} | null> =
         new BehaviorSubject<{tileId: number, mapId: string, layerId: string} | null>(null);
     tileIdsForSourceData: Subject<SourceDataDropdownOption[]> = new Subject<SourceDataDropdownOption[]>();
-    tileOutiline: Subject<Object | null> = new Subject<Object | null>();
+    tileOutiline: Subject<object | null> = new Subject<object | null>();
     customTileAndMapId: Subject<[string, string]> = new Subject<[string, string]>();
 
     constructor(private inspectionService: InspectionService) {

--- a/erdblick_app/app/rightclickmenu.service.ts
+++ b/erdblick_app/app/rightclickmenu.service.ts
@@ -56,7 +56,7 @@ export class RightClickMenuService {
 
     private updateMenuForLastInspectedSourceData(sourceDataParams: {tileId: bigint, mapId: string, layerId: string}) {
         const menuItem = {
-            label: 'Inspect for Last Selected Source Data Parameters',
+            label: 'Inspect Source Data with Last Layer',
             icon: 'pi pi-database',
             command: () => {
                 this.inspectionService.loadSourceDataInspection(

--- a/erdblick_app/app/rightclickmenu.service.ts
+++ b/erdblick_app/app/rightclickmenu.service.ts
@@ -18,7 +18,7 @@ export class RightClickMenuService {
     lastInspectedTileSourceDataOption: BehaviorSubject<{tileId: number, mapId: string, layerId: string} | null> =
         new BehaviorSubject<{tileId: number, mapId: string, layerId: string} | null>(null);
     tileIdsForSourceData: Subject<SourceDataDropdownOption[]> = new Subject<SourceDataDropdownOption[]>();
-    tileOutiline: Subject<object | null> = new Subject<object | null>();
+    tileOutline: Subject<object | null> = new Subject<object | null>();
     customTileAndMapId: Subject<[string, string]> = new Subject<[string, string]>();
 
     constructor(private inspectionService: InspectionService) {

--- a/erdblick_app/app/search.panel.component.ts
+++ b/erdblick_app/app/search.panel.component.ts
@@ -269,7 +269,6 @@ export class SearchPanelComponent implements AfterViewInit {
                 for (let i = 0; i < this.searchItems.length; i++) {
                     // TODO: Introduce a static ID for the action, so we can reference it directly.
                     if (this.searchItems[i].name === "Inspect Tile Layer Source Data") {
-                        console.assert(this.searchItems[i].validate(value))
                         this.parametersService.setSearchHistoryState([i, value]);
                         break;
                     }

--- a/erdblick_app/app/search.panel.component.ts
+++ b/erdblick_app/app/search.panel.component.ts
@@ -258,18 +258,18 @@ export class SearchPanelComponent implements AfterViewInit {
                     .replace(/Ü/g, "Ue");
                 this.searchInputValue = query;
                 this.runTarget(entry[0]);
+                this.sidePanelService.panel = SidePanelState.NONE;
             }
             this.reloadSearchHistory();
         });
 
         this.menuService.lastInspectedTileSourceDataOption.subscribe(lastInspectedData => {
             if (lastInspectedData && lastInspectedData.tileId && lastInspectedData.mapId && lastInspectedData.layerId) {
-                const value = `${lastInspectedData?.tileId} ${lastInspectedData?.mapId} ${lastInspectedData?.layerId}`;
+                const value = `${lastInspectedData?.tileId} "${lastInspectedData?.mapId}" "${lastInspectedData?.layerId}"`;
                 for (let i = 0; i < this.searchItems.length; i++) {
-                    if (!this.searchItems[i].name.toLowerCase().includes("features") &&
-                        this.searchItems[i].validate(value)) {
-                        console.log("VALIDATED")
-                        console.log("SET HISTORY")
+                    // TODO: Introduce a static ID for the action, so we can reference it directly.
+                    if (this.searchItems[i].name === "Inspect Tile Layer Source Data") {
+                        console.assert(this.searchItems[i].validate(value))
                         this.parametersService.setSearchHistoryState([i, value]);
                         break;
                     }
@@ -523,8 +523,8 @@ export class SearchPanelComponent implements AfterViewInit {
 
     onKeydown(event: KeyboardEvent) {
         if (event.key === 'Enter') {
-            if (this.searchInputValue.trim()) {
-                this.parametersService.setSearchHistoryState([0, this.searchInputValue]);
+            if (this.searchInputValue.trim() && this.activeSearchItems.length) {
+                this.parametersService.setSearchHistoryState([this.activeSearchItems[0].index, this.searchInputValue]);
             } else {
                 this.parametersService.setSearchHistoryState(null);
             }

--- a/erdblick_app/app/sourcedata.panel.component.ts
+++ b/erdblick_app/app/sourcedata.panel.component.ts
@@ -282,8 +282,13 @@ export class SourceDataPanelComponent implements OnInit, AfterViewInit, OnDestro
                 });
             }
 
-            if (address === undefined && node.children?.length == 1) {
+            if (address === undefined && node.children && node.children.length < 5) {
                 node.expanded = true;
+                for (const child of node.children) {
+                    if (child.children && child.children.length < 5) {
+                        child.expanded = true;
+                    }
+                }
             }
 
             if (node.children) {
@@ -297,7 +302,14 @@ export class SourceDataPanelComponent implements OnInit, AfterViewInit, OnDestro
 
         if (address === undefined) {
             for (const item of this.treeData) {
-                item.expanded = true;
+                if (item.children) {
+                    item.expanded = true;
+                    for (const child of item.children) {
+                        if (child.children && child.children.length < 5) {
+                            child.expanded = true;
+                        }
+                    }
+                }
             }
         }
 

--- a/erdblick_app/app/sourcedata.panel.component.ts
+++ b/erdblick_app/app/sourcedata.panel.component.ts
@@ -126,18 +126,6 @@ export class SourceDataPanelComponent implements OnInit, AfterViewInit, OnDestro
     inspectionContainerHeight: number;
     containerSizeSubscription: Subscription;
 
-    /**
-     * Returns a human-readable layer name for a layer id.
-     *
-     * @param layerId Layer id to get the name for
-     */
-    public static layerNameForLayerId(layerId: string) {
-        const match = layerId.match(/^SourceData-([^.]+\.)*(.*)-([\d]+)/);
-        if (match)
-            return `${match[2]}.${match[3]}`;
-        return layerId;
-    }
-
     constructor(private inspectionService: InspectionService,
                 public parameterService: ParametersService,
                 private renderer: Renderer2,

--- a/erdblick_app/app/sourcedataselection.dialog.component.ts
+++ b/erdblick_app/app/sourcedataselection.dialog.component.ts
@@ -126,16 +126,16 @@ export class SourceDataLayerSelectionDialogComponent {
 
     *findMapsForTileId(tileId: bigint): Generator<SourceDataDropdownOption> {
         const level = coreLib.getTileLevel(tileId);
-        for (const [mapId, mapInfo] of this.mapService.maps.getValue().entries()) {
+        for (const [_, mapInfo] of this.mapService.maps.getValue().entries()) {
             for (const [_, layerInfo] of mapInfo.layers.entries()) {
                 if (layerInfo.type == "SourceData") {
                     if (layerInfo.zoomLevels.includes(level)) {
-                        yield { id: mapId, name: mapId };
+                        yield { id: mapInfo.mapId, name: mapInfo.mapId };
                         break;
                     } else {
                         for (const featureTile of this.mapService.loadedTileLayers.values()) {
                             if (featureTile.tileId == tileId) {
-                                yield { id: mapId, name: mapId };
+                                yield { id: mapInfo.mapId, name: mapInfo.mapId };
                                 break;
                             }
                         }
@@ -227,7 +227,7 @@ export class SourceDataLayerSelectionDialogComponent {
             }
             return [...dataLayers].map(layerId => ({
                 id: layerId,
-                name: SourceDataPanelComponent.layerNameForLayerId(layerId)
+                name: this.inspectionService.layerNameForLayerId(layerId)
             }));
         }
         return [];
@@ -254,6 +254,7 @@ export class SourceDataLayerSelectionDialogComponent {
             mapId: String(this.selectedMapId.id),
             layerId: String(this.selectedSourceDataLayer.id)
         });
+        // TODO: TBR
         // const tileId = this.customTileId ? this.customTileId : this.selectedTileId?.id;
         // this.inspectionService.loadSourceDataInspection(
         //     Number(tileId),

--- a/erdblick_app/app/sourcedataselection.dialog.component.ts
+++ b/erdblick_app/app/sourcedataselection.dialog.component.ts
@@ -129,16 +129,9 @@ export class SourceDataLayerSelectionDialogComponent {
         for (const [_, mapInfo] of this.mapService.maps.getValue().entries()) {
             for (const [_, layerInfo] of mapInfo.layers.entries()) {
                 if (layerInfo.type == "SourceData") {
-                    if (layerInfo.zoomLevels.includes(level)) {
+                    if (!layerInfo.zoomLevels.length || layerInfo.zoomLevels.includes(level)) {
                         yield { id: mapInfo.mapId, name: mapInfo.mapId };
                         break;
-                    } else {
-                        for (const featureTile of this.mapService.loadedTileLayers.values()) {
-                            if (featureTile.tileId == tileId) {
-                                yield { id: mapInfo.mapId, name: mapInfo.mapId };
-                                break;
-                            }
-                        }
                     }
                 }
             }
@@ -166,6 +159,7 @@ export class SourceDataLayerSelectionDialogComponent {
                 this.mapIds.push(mapId);
             }
             this.selectedMapId = mapId;
+            this.findLayersForMapId(mapId.id);
             this.onMapIdChange(this.selectedMapId);
             if (this.sourceDataLayers.length) {
                 this.selectedSourceDataLayer = this.sourceDataLayers[0];
@@ -227,7 +221,7 @@ export class SourceDataLayerSelectionDialogComponent {
             }
             return [...dataLayers].map(layerId => ({
                 id: layerId,
-                name: this.inspectionService.layerNameForLayerId(layerId)
+                name: this.inspectionService.layerNameForSourceDataLayerId(layerId)
             }));
         }
         return [];
@@ -254,13 +248,6 @@ export class SourceDataLayerSelectionDialogComponent {
             mapId: String(this.selectedMapId.id),
             layerId: String(this.selectedSourceDataLayer.id)
         });
-        // TODO: TBR
-        // const tileId = this.customTileId ? this.customTileId : this.selectedTileId?.id;
-        // this.inspectionService.loadSourceDataInspection(
-        //     Number(tileId),
-        //     String(this.selectedMapId?.id),
-        //     String(this.selectedSourceDataLayer?.id)
-        // );
         this.close();
     }
 

--- a/erdblick_app/app/sourcedataselection.dialog.component.ts
+++ b/erdblick_app/app/sourcedataselection.dialog.component.ts
@@ -101,7 +101,7 @@ export class SourceDataLayerSelectionDialogComponent {
         this.mapIds = [];
         this.sourceDataLayers = [];
         this.loading = false;
-        this.menuService.tileOutiline.next(null);
+        this.menuService.tileOutline.next(null);
 
         // Special case: There is a custom tile ID.
         if (customTileId) {
@@ -126,7 +126,7 @@ export class SourceDataLayerSelectionDialogComponent {
 
         // Pre-select the tile ID.
         let tileIdSelection = this.tileIds.find(element =>
-            !element.disabled && [...this.mapService.tileLayersForTileId(element.id as bigint)]
+            !element.disabled && [...this.mapService.tileLayersForTileId(element.id as bigint)].length
         );
         if (tileIdSelection) {
             this.setCurrentTileId(tileIdSelection);
@@ -204,19 +204,19 @@ export class SourceDataLayerSelectionDialogComponent {
     }
 
     outlineTheTileBox(tileId: bigint, color: Color) {
-        this.menuService.tileOutiline.next(null);
+        this.menuService.tileOutline.next(null);
         const tileBox = coreLib.getTileBox(tileId);
         const entity = {
             rectangle: {
                 coordinates: Rectangle.fromDegrees(...tileBox),
                 height: HeightReference.CLAMP_TO_GROUND,
-                material: Color.TRANSPARENT,
-                outlineWidth: 2,
+                material: color.withAlpha(0.2),
                 outline: true,
-                outlineColor: color.withAlpha(0.5)
+                outlineWidth: 3.,
+                outlineColor: color
             }
         }
-        this.menuService.tileOutiline.next(entity);
+        this.menuService.tileOutline.next(entity);
     }
 
     findLayersForMapId(mapId: string) {
@@ -285,6 +285,7 @@ export class SourceDataLayerSelectionDialogComponent {
         this.sourceDataLayers = [];
         this.showCustomTileIdInput = false;
         this.customTileId = "";
+        this.menuService.tileOutline.next(null);
     }
 
     close() {

--- a/erdblick_app/app/sourcedataselection.dialog.component.ts
+++ b/erdblick_app/app/sourcedataselection.dialog.component.ts
@@ -125,7 +125,9 @@ export class SourceDataLayerSelectionDialogComponent {
         }
 
         // Pre-select the tile ID.
-        let tileIdSelection = this.tileIds.find(element => !element.disabled);
+        let tileIdSelection = this.tileIds.find(element =>
+            !element.disabled && [...this.mapService.tileLayersForTileId(element.id as bigint)]
+        );
         if (tileIdSelection) {
             this.setCurrentTileId(tileIdSelection);
         }

--- a/erdblick_app/app/view.component.ts
+++ b/erdblick_app/app/view.component.ts
@@ -147,7 +147,7 @@ export class ErdblickViewComponent implements AfterViewInit {
                 const latitude = CesiumMath.toDegrees(cartographic.latitude);
                 this.menuService.tileIdsForSourceData.next([...Array(16).keys()].map(level => {
                     const tileId = coreLib.getTileIdFromPosition(longitude, latitude, level);
-                    return {id: tileId, name: `${tileId} (level ${level})`};
+                    return {id: tileId, name: `${tileId} (level ${level})`, tileLevel: level};
                 }));
             } else {
                 this.menuService.tileIdsForSourceData.next([]);

--- a/erdblick_app/app/view.component.ts
+++ b/erdblick_app/app/view.component.ts
@@ -38,7 +38,7 @@ declare let window: DebugWindow;
     selector: 'erdblick-view',
     template: `
         <div #viewer id="mapViewContainer" class="mapviewer-renderlayer" style="z-index: 0"></div>
-        <p-contextMenu [target]="viewer" [model]="menuService.menuItems" />
+        <p-contextMenu [target]="viewer" [model]="menuItems" />
         <sourcedatadialog></sourcedatadialog>
     `,
     styles: [`
@@ -55,6 +55,8 @@ export class ErdblickViewComponent implements AfterViewInit {
     private mouseHandler: ScreenSpaceEventHandler | null = null;
     private openStreetMapLayer: ImageryLayer | null = null;
     private marker: Entity | null = null;
+    private tileOutlineEntity: Entity | null = null;
+    menuItems: MenuItem[] = [];
     private cameraIsMoving: boolean = false;
 
     /**
@@ -102,6 +104,10 @@ export class ErdblickViewComponent implements AfterViewInit {
                     roll: 0 // No rotation.
                 }
             );
+        });
+
+        this.menuService.menuItems.subscribe(items => {
+            this.menuItems = [...items];
         });
     }
 
@@ -172,6 +178,7 @@ export class ErdblickViewComponent implements AfterViewInit {
             }
             if (!defined(feature)) {
                 this.inspectionService.isInspectionPanelVisible = false;
+                this.menuService.tileOutiline.next(null);
             }
             this.mapService.highlightFeatures(
                 Array.isArray(feature?.id) ? feature.id : [feature?.id],
@@ -304,6 +311,14 @@ export class ErdblickViewComponent implements AfterViewInit {
         if (spinner) {
             spinner.style.display = 'none';
         }
+
+        this.menuService.tileOutiline.subscribe(entity => {
+            if (entity) {
+                this.tileOutlineEntity = this.viewer.entities.add(entity);
+            } else if (this.tileOutlineEntity) {
+                this.viewer.entities.remove(this.tileOutlineEntity);
+            }
+        });
     }
 
     /**

--- a/erdblick_app/app/view.component.ts
+++ b/erdblick_app/app/view.component.ts
@@ -38,7 +38,7 @@ declare let window: DebugWindow;
     selector: 'erdblick-view',
     template: `
         <div #viewer id="mapViewContainer" class="mapviewer-renderlayer" style="z-index: 0"></div>
-        <p-contextMenu [target]="viewer" [model]="menuItems" />
+        <p-contextMenu [target]="viewer" [model]="menuItems" (onHide)="onContextMenuHide()" />
         <sourcedatadialog></sourcedatadialog>
     `,
     styles: [`
@@ -178,7 +178,7 @@ export class ErdblickViewComponent implements AfterViewInit {
             }
             if (!defined(feature)) {
                 this.inspectionService.isInspectionPanelVisible = false;
-                this.menuService.tileOutiline.next(null);
+                this.menuService.tileOutline.next(null);
             }
             this.mapService.highlightFeatures(
                 Array.isArray(feature?.id) ? feature.id : [feature?.id],
@@ -312,11 +312,13 @@ export class ErdblickViewComponent implements AfterViewInit {
             spinner.style.display = 'none';
         }
 
-        this.menuService.tileOutiline.subscribe(entity => {
+        this.menuService.tileOutline.subscribe(entity => {
             if (entity) {
                 this.tileOutlineEntity = this.viewer.entities.add(entity);
+                this.viewer.scene.requestRender();
             } else if (this.tileOutlineEntity) {
                 this.viewer.entities.remove(this.tileOutlineEntity);
+                this.viewer.scene.requestRender();
             }
         });
     }
@@ -480,5 +482,11 @@ export class ErdblickViewComponent implements AfterViewInit {
             pitch: CesiumMath.toRadians(-90.0),
             roll: 0.0
         });
+    }
+
+    onContextMenuHide() {
+        if (!this.menuService.tileSourceDataDialogVisible) {
+            this.menuService.tileOutline.next(null)
+        }
     }
 }

--- a/erdblick_app/styles.scss
+++ b/erdblick_app/styles.scss
@@ -42,7 +42,7 @@ body {
   }
 
   .p-contextmenu {
-    width: 20em;
+    width: 22em;
   }
 }
 
@@ -457,6 +457,10 @@ body {
 
     .blue {
       background-color: var(--primary-color);
+    }
+
+    .red {
+      background-color: indianred;
     }
 
     .orange {

--- a/erdblick_app/styles.scss
+++ b/erdblick_app/styles.scss
@@ -1051,6 +1051,29 @@ body {
   flex-direction: column;
   gap: 0.5em;
 
+  .main-dropdown {
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    gap: 0.5em;
+
+    p-dropdown {
+      width: 100%;
+    }
+
+    .p-inputtext {
+      width: 100%;
+    }
+
+    button {
+      padding-left: 0;
+      padding-right: 0;
+      width: 2.85em;
+      height: 2.85em;
+      box-shadow: none;
+    }
+  }
+
   .p-dropdown {
     width: 100%;
   }


### PR DESCRIPTION
**Goal**: allow users to access tile's source data via a right-click menu.

**Scope**:

- #160
* InspectionPanelComponent
* ParametersService
* RightClickMenuService
* SourceDataPanelComponent
* TileSourcesComponent
* ViewComponent

**Deliverables**:
- A UI component that allows to select tile IDs, map IDs and source data layer IDs.

**How to test**:
1. Build as usual.
2. Serve.

**Notes**:
* Should we keep tiles' context menu separate or introduce a global context menu with everything together?

**TODO**:

- [x] When source data is selected without address, expand 1st level for each SourceData node.
- [x] Pre-select the first tile-id which is present in the currently loaded tile layers.