### PR TITLE
Allow proxy and tile legal information support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ message("Building for ${CMAKE_SYSTEM_NAME}.")
 if (NOT TARGET mapget)
   FetchContent_Declare(mapget
     GIT_REPOSITORY "https://github.com/Klebert-Engineering/mapget"
-    GIT_TAG        "v2024.5.0"
+    GIT_TAG        "legal-info-entry"
     GIT_SHALLOW    ON)
   FetchContent_MakeAvailable(mapget)
 endif()

--- a/angular.json
+++ b/angular.json
@@ -105,7 +105,17 @@
                                     "input": ".",
                                     "output": "/bundle/"
                                 }
-                            ]
+                            ],
+                            "buildOptimizer": true,
+                            "optimization": {
+                                "scripts": true,
+                                "styles": true,
+                                "fonts": true
+                            },
+                            "vendorChunk": false,
+                            "extractLicenses": false,
+                            "sourceMap": false,
+                            "namedChunks": false
                         },
                         "development": {
                             "buildOptimizer": false,
@@ -120,7 +130,7 @@
                             "namedChunks": true
                         }
                     },
-                    "defaultConfiguration": "development"
+                    "defaultConfiguration": "production"
                 },
                 "serve": {
                     "builder": "@angular-builders/custom-webpack:dev-server",

--- a/build-ui.bash
+++ b/build-ui.bash
@@ -15,10 +15,10 @@ npm install
 
 echo "Building Angular distribution files."
 npm run lint
-if [[ -z "$NG_DEVELOP" ]]; then
-  npm run build -- -c production
+if [[ -n "$NG_DEVELOP" ]]; then
+  npm run build -- -c development
 else
-  npm run build --watch
+  npm run build
 fi
 
 exit 0

--- a/erdblick_app/app/app.component.ts
+++ b/erdblick_app/app/app.component.ts
@@ -18,6 +18,10 @@ import {filter} from "rxjs";
         <pref-components></pref-components>
         <coordinates-panel></coordinates-panel>
         <stats-dialog></stats-dialog>
+        <legal-dialog></legal-dialog>
+        <div *ngIf="copyright.length" id="copyright-info" (click)="openLegalInfo()">
+            {{ copyright }}
+        </div>
         <div id="info">
             {{ title }} {{ version }}
         </div>
@@ -36,19 +40,25 @@ export class AppComponent {
 
     title: string = "erdblick";
     version: string = "";
+    copyright: string = "";
 
     constructor(private httpClient: HttpClient,
                 private router: Router,
                 private activatedRoute: ActivatedRoute,
                 public mapService: MapService,
-                public styleService: StyleService,
-                public jumpToTargetService: JumpTargetService,
                 public parametersService: ParametersService) {
         this.httpClient.get('./bundle/VERSION', {responseType: 'text'}).subscribe(
             data => {
                 this.version = data.toString();
             });
         this.init();
+        this.mapService.legalInformationUpdated.subscribe(_ => {
+            this.copyright = "";
+            let firstSet: Set<string> | undefined = this.mapService.legalInformationPerMap.values().next().value;
+            if (firstSet !== undefined && firstSet.size) {
+                this.copyright = '© '.concat(firstSet.values().next().value as string).slice(0, 14).concat('…');
+            }
+        });
     }
 
     init() {
@@ -82,5 +92,9 @@ export class AppComponent {
             queryParamsHandling: 'merge',
             replaceUrl: replaceUrl
         });
+    }
+
+    openLegalInfo() {
+        this.parametersService.legalInfoDialogVisible = true;
     }
 }

--- a/erdblick_app/app/app.module.ts
+++ b/erdblick_app/app/app.module.ts
@@ -76,6 +76,7 @@ import {StatsDialogComponent} from "./stats.component";
 import {SourceDataLayerSelectionDialogComponent} from "./sourcedataselection.dialog.component";
 import {ContextMenuModule} from "primeng/contextmenu";
 import {RightClickMenuService} from "./rightclickmenu.service";
+import {LegalInfoDialogComponent} from "./legalinfo.component";
 
 export function initializeServices(styleService: StyleService, mapService: MapService, coordService: CoordinatesService) {
     return async () => {
@@ -152,7 +153,8 @@ export function typeValidationMessage({ schemaType }: any) {
         HighlightSearch,
         TreeTableFilterPatchDirective,
         StatsDialogComponent,
-        SourceDataLayerSelectionDialogComponent
+        SourceDataLayerSelectionDialogComponent,
+        LegalInfoDialogComponent
     ],
     bootstrap: [
         AppComponent

--- a/erdblick_app/app/coordinates.service.ts
+++ b/erdblick_app/app/coordinates.service.ts
@@ -20,7 +20,7 @@ export class CoordinatesService {
     }
 
     initialize() {
-        this.httpClient.get("/config.json", {responseType: 'json'}).subscribe({
+        this.httpClient.get("config.json", {responseType: 'json'}).subscribe({
             next: (data: any) => {
                 try {
                     if (data && data["extensionModules"] && data["extensionModules"]["jumpTargets"]) {

--- a/erdblick_app/app/datasources.service.ts
+++ b/erdblick_app/app/datasources.service.ts
@@ -19,7 +19,7 @@ export class DataSourcesService {
 
     postConfig(config: string) {
         this.loading = true;
-        this.http.post("/config", config, { observe: 'response', responseType: 'text' }).subscribe({
+        this.http.post("config", config, { observe: 'response', responseType: 'text' }).subscribe({
             next: (data: any) => {
                 this.messageService.showSuccess(data.body);
                 setTimeout(() => {
@@ -38,7 +38,7 @@ export class DataSourcesService {
         this.readOnly = true;
         this.errorMessage = "";
         this.loading = true;
-        this.http.get("/config").subscribe({
+        this.http.get("config").subscribe({
             next: (data: any) => {
                 if (!data) {
                     this.errorMessage = "Unknown error: DataSources configuration data is missing!";

--- a/erdblick_app/app/features.model.ts
+++ b/erdblick_app/app/features.model.ts
@@ -14,6 +14,7 @@ export class FeatureTile {
     mapName: string;
     layerName: string;
     tileId: bigint;
+    legalInfo: string;
     numFeatures: number;
     private parser: TileLayerParser;
     preventCulling: boolean;
@@ -39,6 +40,7 @@ export class FeatureTile {
         this.mapName = mapTileMetadata.mapName;
         this.layerName = mapTileMetadata.layerName;
         this.tileId = mapTileMetadata.tileId;
+        this.legalInfo = mapTileMetadata.legalInfo;
         this.numFeatures = mapTileMetadata.numFeatures;
         this.stats.set(FeatureTile.statTileSize, [tileFeatureLayerBlob.length/1024]);
         for (let [k, v] of Object.entries(mapTileMetadata.scalarFields)) {

--- a/erdblick_app/app/inspection.service.ts
+++ b/erdblick_app/app/inspection.service.ts
@@ -273,7 +273,7 @@ export class InspectionService {
         });
 
         let layer: TileSourceDataLayer | undefined;
-        let fetch = new Fetch("/tiles")
+        let fetch = new Fetch("tiles")
             .withChunkProcessing()
             .withMethod("POST")
             .withBody(newRequestBody)

--- a/erdblick_app/app/jump.service.ts
+++ b/erdblick_app/app/jump.service.ts
@@ -51,7 +51,7 @@ export class JumpTargetService {
                 private inspectionService: InspectionService,
                 private menuService: RightClickMenuService,
                 private searchService: FeatureSearchService) {
-        this.httpClient.get("/config.json", {responseType: 'json'}).subscribe({
+        this.httpClient.get("config.json", {responseType: 'json'}).subscribe({
             next: (data: any) => {
                 try {
                     if (data && data["extensionModules"] && data["extensionModules"]["jumpTargets"]) {
@@ -327,7 +327,7 @@ export class JumpTargetService {
             mapId: mapId,
             featureId: action.idParts.map((kv) => [kv.key, kv.value]).flat()
         }]};
-        let response = await fetch("/locate", {
+        let response = await fetch("locate", {
             body: JSON.stringify(resolveMe),
             method: "POST"
         }).catch((err)=>console.error(`Error during /locate call: ${err}`));

--- a/erdblick_app/app/legalinfo.component.ts
+++ b/erdblick_app/app/legalinfo.component.ts
@@ -1,0 +1,74 @@
+import { Component } from "@angular/core";
+import { MapService } from "./map.service";
+import { ParametersService } from "./parameters.service";
+
+@Component({
+    selector: 'legal-dialog',
+    template: `
+        <p-dialog header="Copyright and Legal Information" [(visible)]="parametersService.legalInfoDialogVisible" [modal]="false"
+                  [style]="{'min-height': '10em', 'min-width': '40em'}">
+            <div class="dialog-content">
+                <table class="stats-table">
+                    <thead>
+                        <tr>
+                            <th>Map Name</th>
+                            <th>Legal Information</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr *ngFor="let info of aggregatedLegalInfo">
+                            <td>{{ info.mapName }}</td>
+                            <td>{{ info.entry }}</td>
+                        </tr>
+                    </tbody>
+                </table>
+                <button pButton type="button" label="Close" icon="pi pi-cross" (click)="close()"></button>
+            </div>
+        </p-dialog>
+    `,
+    styles: [
+        `
+            .dialog-content {
+                display: flex;
+                flex-direction: column;
+                gap: 1em;
+            }
+            .stats-table {
+                width: 100%;
+                border-collapse: collapse;
+            }
+            .stats-table th, .stats-table td {
+                border: 1px solid #ccc;
+                padding: 0.5em;
+                text-align: left;
+            }
+            .stats-table th {
+                background-color: #f9f9f9;
+                font-weight: bold;
+            }
+        `
+    ]
+})
+export class LegalInfoDialogComponent {
+    public aggregatedLegalInfo: { mapName: string, entry: string }[] = [];
+
+    constructor(private mapService: MapService,
+                public parametersService: ParametersService) {
+        this.mapService.legalInformationUpdated.subscribe(_ => {
+            this.aggregatedLegalInfo = [];
+            this.mapService.legalInformationPerMap.forEach((entries, mapName) => {
+                if (entries.size) {
+                    this.aggregatedLegalInfo.push({
+                        mapName: mapName,
+                        entry: Array.from(entries).join('\n\n')
+                    })
+                }
+            });
+        });
+    }
+
+    close() {
+        this.parametersService.legalInfoDialogVisible = false;
+    }
+}
+

--- a/erdblick_app/app/map.service.ts
+++ b/erdblick_app/app/map.service.ts
@@ -48,9 +48,9 @@ export interface MapInfoItem extends Record<string, any> {
     visible: boolean;
 }
 
-const infoUrl = "/sources";
-const tileUrl = "/tiles";
-const abortUrl = "/abort";
+const infoUrl = "sources";
+const tileUrl = "tiles";
+const abortUrl = "abort";
 
 /** Redefinition of coreLib.Viewport. TODO: Check if needed. */
 type ViewportProperties = {

--- a/erdblick_app/app/parameters.service.ts
+++ b/erdblick_app/app/parameters.service.ts
@@ -218,6 +218,8 @@ export class ParametersService {
     private baseCameraZoomM = 100.0;
     private scalingFactor = 1;
 
+    legalInfoDialogVisible: boolean = false;
+
     constructor(public router: Router) {
         this.baseFontSize = parseFloat(window.getComputedStyle(document.documentElement).fontSize);
 

--- a/erdblick_app/app/style.service.ts
+++ b/erdblick_app/app/style.service.ts
@@ -73,7 +73,7 @@ export class StyleService {
 
     async initializeStyles(): Promise<void> {
         try {
-            const data: any = await firstValueFrom(this.httpClient.get("/config.json", {responseType: "json"}));
+            const data: any = await firstValueFrom(this.httpClient.get("config.json", {responseType: "json"}));
             if (!data || !data.styles) {
                 throw new Error("Missing style configuration in config.json.");
             }

--- a/erdblick_app/app/style.service.ts
+++ b/erdblick_app/app/style.service.ts
@@ -80,8 +80,8 @@ export class StyleService {
 
             let styleUrls = [...data["styles"]] as [StyleConfigEntry];
             styleUrls.forEach((styleEntry: StyleConfigEntry) => {
-                if (!styleEntry.url.startsWith("http") && !styleEntry.url.startsWith("/bundle")) {
-                    styleEntry.url = `/bundle/styles/${styleEntry.url}`;
+                if (!styleEntry.url.startsWith("http") && !styleEntry.url.startsWith("bundle")) {
+                    styleEntry.url = `bundle/styles/${styleEntry.url}`;
                 }
             });
 

--- a/erdblick_app/app/visualization.model.ts
+++ b/erdblick_app/app/visualization.model.ts
@@ -241,7 +241,7 @@ export class TileVisualization {
                 // Try to resolve externally referenced auxiliary tiles.
                 let extRefs = {requests: wasmVisualization.externalReferences()};
                 if (extRefs.requests && extRefs.requests.length > 0) {
-                    let response = await fetch("/locate", {
+                    let response = await fetch("locate", {
                         body: JSON.stringify(extRefs, (_, value) =>
                             typeof value === 'bigint'
                                 ? Number(value)

--- a/erdblick_app/main.ts
+++ b/erdblick_app/main.ts
@@ -8,7 +8,7 @@ declare global {
         CESIUM_BASE_URL: string
     }
 }
-window.CESIUM_BASE_URL = '/bundle/cesium/';
+window.CESIUM_BASE_URL = 'bundle/cesium/';
 
 platformBrowserDynamic().bootstrapModule(AppModule)
   .catch(err => console.error(err));

--- a/erdblick_app/styles.scss
+++ b/erdblick_app/styles.scss
@@ -79,6 +79,29 @@ body {
   line-height: 1.5em;
   padding-bottom: 0.25em;
   border-radius: 5px 0 0 0;
+  height: 1.75em;
+  width: 10em;
+}
+
+#copyright-info {
+  position: absolute;
+  right: 0;
+  bottom: 1.75em;
+  justify-content: center;
+  display: flex;
+  font-size: 0.8em;
+  background-color: rgba(#fff, 0.25);
+  color: black;
+  padding-right: 0.5em;
+  padding-left: 0.5em;
+  line-height: 1.5em;
+  padding-bottom: 0.25em;
+  border-radius: 5px 0 0 5px;
+  overflow: hidden;
+  height: 1.75em;
+  width: 10em;
+  z-index: 100;
+  cursor: pointer;
 }
 
 .help-button {

--- a/libs/core/include/erdblick/layer.h
+++ b/libs/core/include/erdblick/layer.h
@@ -42,6 +42,12 @@ struct TileFeatureLayer
     mapget::Point center() const;
 
     /**
+     * Retrieves the legal information / copyright of the tile feature layer as a string.
+     * @return The legal information string.
+     */
+    std::string legalInfo() const;
+
+    /**
      * Finds a feature within the tile by its ID.
      * @param id The ID of the feature to find.
      * @return A pointer to the found feature, or `nullptr` if not found.

--- a/libs/core/include/erdblick/parser.h
+++ b/libs/core/include/erdblick/parser.h
@@ -49,6 +49,7 @@ public:
         std::string mapName;
         std::string layerName;
         uint64_t tileId;
+        std::string legalInfo;
         int32_t numFeatures;
         NativeJsValue scalarFields;
     };

--- a/libs/core/src/bindings.cpp
+++ b/libs/core/src/bindings.cpp
@@ -449,6 +449,7 @@ EMSCRIPTEN_BINDINGS(erdblick)
         .field("mapName", &TileLayerParser::TileLayerMetadata::mapName)
         .field("layerName", &TileLayerParser::TileLayerMetadata::layerName)
         .field("tileId", &TileLayerParser::TileLayerMetadata::tileId)
+        .field("legalInfo", &TileLayerParser::TileLayerMetadata::legalInfo)
         .field("numFeatures", &TileLayerParser::TileLayerMetadata::numFeatures)
         .field("scalarFields", &TileLayerParser::TileLayerMetadata::scalarFields);
 

--- a/libs/core/src/layer.cpp
+++ b/libs/core/src/layer.cpp
@@ -52,6 +52,15 @@ mapget::Point TileFeatureLayer::center() const
 }
 
 /**
+ * Retrieves the legal information / copyright of the tile feature layer as a string.
+ * @return The legal information string.
+ */
+std::string TileFeatureLayer::legalInfo() const
+{
+    return model_->legalInfo() ? *model_->legalInfo() : "";
+}
+
+/**
  * Finds a feature within the tile by its ID.
  * @param id The ID of the feature to find.
  * @return A pointer to the found feature, or `nullptr` if not found.

--- a/libs/core/src/parser.cpp
+++ b/libs/core/src/parser.cpp
@@ -151,6 +151,7 @@ TileLayerParser::TileLayerMetadata TileLayerParser::readTileLayerMetadata(const 
         tileLayer.id().mapId_,
         tileLayer.id().layerId_,
         tileLayer.tileId().value_,
+        tileLayer.legalInfo() ? *tileLayer.legalInfo() : "",
         numFeatures,
         *allScalarFields
     };


### PR DESCRIPTION
**Goal**: allow users to:

- configure proxy when using erdblick
- access legal information (per map) if it is set on any loaded tiles

**Scope**:

* Angular app and WASM sources 

**Deliverables**:
- erdblick is using relative paths for http calls (necessary for proxy support)
- legal information for tiles is propagated from mapget to MapService

**How to test**:
1. Build as usual.
2. Serve with Island 1.
3. Configure a basic proxy as follows:
```nginx
server {
    listen 80;
    server_name <your-server-name>;
    
    location /<your-sub-path>/ {
        proxy_pass http://127.0.0.1:8089/;
        
        proxy_http_version 1.1;
        proxy_set_header Host $host;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Proto $scheme;
        proxy_set_header Upgrade $http_upgrade;
        proxy_set_header Connection "upgrade";
        
        # Replace absolute paths in HTML/JS responses
        sub_filter_types text/html;
        sub_filter 'src="/' 'src="/<your-sub-path>/';
        sub_filter 'href="/' 'href="/<your-sub-path>/';
        sub_filter_once off;
    }
    
    # Handle absolute path requests by forwarding them to the app path
    location / {
        rewrite ^/bundle/(.*) /<your-sub-path>/bundle/$1 last;
        rewrite ^/config.json /<your-sub-path>/config.json last;
        rewrite ^/favicon.ico /<your-sub-path>/favicon.ico last;
        return 404;
    }
}
```
4. Examine tiles' legal information if present by clicking the link in the bottom right corner (only shown if there is any legal information).