### PR TITLE
styles: Fix non-working geometry-name based styles.

### DIFF
--- a/libs/core/include/erdblick/visualization.h
+++ b/libs/core/include/erdblick/visualization.h
@@ -170,6 +170,7 @@ private:
      */
     void addGeometry(
         mapget::SelfContainedGeometry const& geom,
+        std::optional<std::string_view> geometryName,
         std::string_view id,
         FeatureStyleRule const& rule,
         std::string const& mapLayerStyleRuleId,

--- a/libs/core/src/rule.cpp
+++ b/libs/core/src/rule.cpp
@@ -423,8 +423,15 @@ bool FeatureStyleRule::supports(const mapget::GeomType& g, std::optional<std::st
         return false;
     }
 
-    // Ensure that the geometry name is supported by the rule.
+    // Ensure that the geometry name matches the rule's requirements
     if (geometryName_) {
+
+        // Empty regex: explicitly match features without a geometry name
+        // TODO: Check if there is any recognizable performance impact
+        if (std::regex_match("", *geometryName_)) {
+            return !geometryName || geometryName->empty();
+        }
+
         if (!geometryName) {
             return false;
         }

--- a/libs/core/src/visualization.cpp
+++ b/libs/core/src/visualization.cpp
@@ -329,18 +329,19 @@ void FeatureLayerVisualization::addGeometry(
     if (!geom) {
         return;
     }
-    addGeometry(geom->toSelfContained(), id, rule, mapLayerStyleRuleId, evalFun, offset);
+    addGeometry(geom->toSelfContained(), geom->name(), id, rule, mapLayerStyleRuleId, evalFun, offset);
 }
 
 void FeatureLayerVisualization::addGeometry(
     SelfContainedGeometry const& geom,
+    std::optional<std::string_view> geometryName,
     std::string_view id,
     FeatureStyleRule const& rule,
     std::string const& mapLayerStyleRuleId,
     BoundEvalFun& evalFun,
     glm::dvec3 const& offset)
 {
-    if (!rule.supports(geom.geomType_))
+    if (!rule.supports(geom.geomType_, geometryName))
         return;
 
     // Combine the ID with the mapTileKey to create an
@@ -772,6 +773,7 @@ void FeatureLayerVisualization::addAttribute(
         {
             addGeometry(
                 validity.computeGeometry(feature->geomOrNull()),
+                std::nullopt,
                 id,
                 rule,
                 mapLayerStyleRuleId,
@@ -781,8 +783,10 @@ void FeatureLayerVisualization::addAttribute(
         });
     }
     else {
+        auto geom = feature->firstGeometry();
         addGeometry(
-            feature->firstGeometry(),
+            geom,
+            std::nullopt,
             id,
             rule,
             mapLayerStyleRuleId,
@@ -1004,7 +1008,7 @@ void RecursiveRelationVisualizationState::render(
         if (auto sourceRule = rule_.relationSourceStyle()) {
             for (auto const& sourceGeom : sourceGeoms) {
                 if (sourceGeom.points_.empty()) continue;
-                    visu_.addGeometry(sourceGeom, UnselectableId, *sourceRule, "", boundEvalFun, offsetBase * sourceRule->offset());
+                    visu_.addGeometry(sourceGeom, std::nullopt, UnselectableId, *sourceRule, "", boundEvalFun, offsetBase * sourceRule->offset());
             }
         }
     }
@@ -1014,7 +1018,7 @@ void RecursiveRelationVisualizationState::render(
         if (auto targetRule = rule_.relationTargetStyle()) {
             for (auto const& targetGeom : targetGeoms) {
                 if (targetGeom.points_.empty()) continue;
-                    visu_.addGeometry(targetGeom, UnselectableId, *targetRule, "", boundEvalFun, offsetBase * targetRule->offset());
+                    visu_.addGeometry(targetGeom, std::nullopt, UnselectableId, *targetRule, "", boundEvalFun, offsetBase * targetRule->offset());
             }
         }
     }


### PR DESCRIPTION
This PR fixes two problems:

1. Missing availability of the geometry name when using SelfContainedGeometries caused geometry-name based filtering failing in general
2. Allow the user to express that a rule should only apply to features that have no name without removing special cases to avoid unnecessary reg-ex evaluation. 