### PR TITLE
Use Simfils Native Any-Mode for Queries

### DIFF
--- a/libs/core/include/erdblick/search.h
+++ b/libs/core/include/erdblick/search.h
@@ -6,6 +6,13 @@
 namespace erdblick
 {
 
+/**
+ * Wrap the given simfil query in an any operator to ensure, that
+ * it returns a boolean, and limit wildcard evaluations to the necessary
+ * minimum.
+ */
+std::string anyWrap(std::string_view const& q);
+
 class FeatureLayerSearch
 {
 public:

--- a/libs/core/include/erdblick/visualization.h
+++ b/libs/core/include/erdblick/visualization.h
@@ -250,7 +250,7 @@ private:
     /**
      * Simfil expression evaluation function for the tile which this visualization belongs to.
      */
-    simfil::Value evaluateExpression(std::string const& expression, simfil::ModelNode const& ctx, bool anyMode = true) const;
+    simfil::Value evaluateExpression(std::string const& expression, simfil::ModelNode const& ctx) const;
 
     /**
      * Insert style option variables into the given OverlayNode.

--- a/libs/core/include/erdblick/visualization.h
+++ b/libs/core/include/erdblick/visualization.h
@@ -250,7 +250,7 @@ private:
     /**
      * Simfil expression evaluation function for the tile which this visualization belongs to.
      */
-    simfil::Value evaluateExpression(std::string const& expression, simfil::ModelNode const& ctx) const;
+    simfil::Value evaluateExpression(std::string const& expression, simfil::ModelNode const& ctx, bool anyMode, bool autoWildcard) const;
 
     /**
      * Insert style option variables into the given OverlayNode.

--- a/libs/core/src/rule.cpp
+++ b/libs/core/src/rule.cpp
@@ -122,7 +122,7 @@ void FeatureStyleRule::parse(const YAML::Node& yaml)
     }
     if (yaml["filter"].IsDefined()) {
         // Parse a simfil filter expression, e.g. `properties.functionalRoadClass == 4`
-        filter_ = yaml["filter"].as<std::string>();
+        filter_ = anyWrap(yaml["filter"].as<std::string>());
     }
     if (yaml["selectable"].IsDefined()) {
         // Parse the selectable flag.

--- a/libs/core/src/search.cpp
+++ b/libs/core/src/search.cpp
@@ -37,3 +37,9 @@ erdblick::NativeJsValue erdblick::FeatureLayerSearch::traceResults()
     // TODO: Implement
     return {};
 }
+
+std::string erdblick::anyWrap(const std::string_view& q)
+{
+    return fmt::format("any({})", q);
+}
+

--- a/libs/core/src/visualization.cpp
+++ b/libs/core/src/visualization.cpp
@@ -98,7 +98,7 @@ void FeatureLayerVisualization::run()
             evaluationContext,
             [this, &evaluationContext](auto&& str)
             {
-                return evaluateExpression(str, evaluationContext);
+                return evaluateExpression(str, evaluationContext, false, false);
             }};
 
         for (auto&& rule : style_.rules()) {
@@ -680,11 +680,13 @@ void FeatureLayerVisualization::addPolyLine(
 
 simfil::Value FeatureLayerVisualization::evaluateExpression(
     const std::string& expression,
-    const simfil::ModelNode& ctx) const
+    const simfil::ModelNode& ctx,
+    bool anyMode,
+    bool autoWildcard) const
 {
     try
     {
-        auto results = tile_->evaluate(expression, ctx, false);
+        auto results = tile_->evaluate(expression, ctx, anyMode, autoWildcard);
         if (!results.empty()) {
             return std::move(results[0]);
         }
@@ -750,7 +752,7 @@ void FeatureLayerVisualization::addAttribute(
         attrEvaluationContext,
         [this, &attrEvaluationContext](auto&& str)
         {
-            return evaluateExpression(str, attrEvaluationContext);
+            return evaluateExpression(str, attrEvaluationContext, false, false);
         }};
 
     // Bump visual offset factor for next visualized attribute.
@@ -942,7 +944,7 @@ void RecursiveRelationVisualizationState::render(
         relationEvaluationContext,
         [this, &relationEvaluationContext](auto&& str)
         {
-            return visu_.evaluateExpression(str, relationEvaluationContext);
+            return visu_.evaluateExpression(str, relationEvaluationContext, false, false);
         }};
 
     // Obtain source/target geometries.

--- a/libs/core/src/visualization.cpp
+++ b/libs/core/src/visualization.cpp
@@ -680,12 +680,11 @@ void FeatureLayerVisualization::addPolyLine(
 
 simfil::Value FeatureLayerVisualization::evaluateExpression(
     const std::string& expression,
-    const simfil::ModelNode& ctx,
-    bool anyMode /* = true */) const
+    const simfil::ModelNode& ctx) const
 {
     try
     {
-        auto results = tile_->evaluate(expression, ctx, anyMode);
+        auto results = tile_->evaluate(expression, ctx, false);
         if (!results.empty()) {
             return std::move(results[0]);
         }


### PR DESCRIPTION
Waiting for a simfil release to pull in new version.

Changes the use of `wrapAny` to simfil's native any-mode. By wrapping searches in `any(...)`, simfil cannot detect single value queries and therefore is unable to expand them to wildcard queries.