### PR TITLE
Introduce Visualization-Only Mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ if(NOT ${CMAKE_SYSTEM_NAME} STREQUAL "Emscripten")
 else()
   # Angular Build
   add_custom_target(erdblick-ui ALL
-    COMMAND bash "${CMAKE_SOURCE_DIR}/build-ui.bash" "${CMAKE_SOURCE_DIR}"
+    COMMAND bash "${CMAKE_SOURCE_DIR}/build-ui.bash" "${CMAKE_SOURCE_DIR}" all
     WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
     DEPENDS erdblick-core)
 endif()

--- a/README.md
+++ b/README.md
@@ -14,6 +14,37 @@
 
 ![mapget ui](./docs/erdblick.png)
 
+## Build Modes
+
+erdblick can be built in two different modes to suit different use cases:
+
+### Full Mode (Default)
+
+The complete erdblick experience with all features enabled:
+
+* Interactive feature selection and inspection
+* Style editing capabilities
+* Search functionality
+* Coordinate display
+* Statistics and preferences panels
+* Full keyboard navigation support
+
+### Visualization-Only Mode
+
+A streamlined version focused purely on map visualization:
+
+* Map display with all configured styles (with only the options of each style that have `default: true` enabled)
+* Basic camera controls
+* No advanced features like search and inspection
+* Smaller bundle size
+* Perfect for embedding or usage for demo purposes
+
+This mode can be built using:
+
+```bash
+./build-ui.bash /path/to/source visualization-only
+```
+
 ## Setup
 
 Ready to try out the latest version?

--- a/angular.json
+++ b/angular.json
@@ -115,7 +115,13 @@
                             "vendorChunk": false,
                             "extractLicenses": false,
                             "sourceMap": false,
-                            "namedChunks": false
+                            "namedChunks": false,
+                            "fileReplacements": [
+                                {
+                                    "replace": "erdblick_app/environments/environment.ts",
+                                    "with": "erdblick_app/environments/environment.prod.ts"
+                                }
+                            ]
                         },
                         "development": {
                             "buildOptimizer": false,
@@ -127,7 +133,71 @@
                             "vendorChunk": true,
                             "extractLicenses": false,
                             "sourceMap": true,
-                            "namedChunks": true
+                            "namedChunks": true,
+                            "fileReplacements": [
+                                {
+                                    "replace": "erdblick_app/environments/environment.ts",
+                                    "with": "erdblick_app/environments/environment.ts"
+                                }
+                            ]
+                        },
+                        "visualization-only": {
+                            "budgets": [
+                                {
+                                    "type": "initial",
+                                    "maximumWarning": "500kb",
+                                    "maximumError": "100mb"
+                                },
+                                {
+                                    "type": "anyComponentStyle",
+                                    "maximumWarning": "2kb",
+                                    "maximumError": "4kb"
+                                }
+                            ],
+                            "outputHashing": "all",
+                            "assets": [
+                                {
+                                    "glob": "**/*",
+                                    "input": "node_modules/cesium/Build/Cesium",
+                                    "output": "/bundle/cesium"
+                                },
+                                {
+                                    "glob": "**/*",
+                                    "input": "config/styles",
+                                    "output": "/bundle/styles"
+                                },
+                                {
+                                    "glob": "**/*",
+                                    "input": "images",
+                                    "output": "/bundle/images"
+                                },
+                                {
+                                    "glob": "**/*.json",
+                                    "input": "config",
+                                    "output": "/"
+                                },
+                                {
+                                    "glob": "VERSION",
+                                    "input": ".",
+                                    "output": "/bundle/"
+                                }
+                            ],
+                            "buildOptimizer": true,
+                            "optimization": {
+                                "scripts": true,
+                                "styles": true,
+                                "fonts": true
+                            },
+                            "vendorChunk": false,
+                            "extractLicenses": false,
+                            "sourceMap": false,
+                            "namedChunks": false,
+                            "fileReplacements": [
+                                {
+                                    "replace": "erdblick_app/environments/environment.ts",
+                                    "with": "erdblick_app/environments/environment.visualization-only.ts"
+                                }
+                            ]
                         }
                     },
                     "defaultConfiguration": "production"
@@ -140,6 +210,9 @@
                         },
                         "development": {
                             "browserTarget": "erdblick:build:development"
+                        },
+                        "visualization-only": {
+                            "browserTarget": "erdblick:build:visualization-only"
                         }
                     },
                     "defaultConfiguration": "development"

--- a/angular.json
+++ b/angular.json
@@ -142,6 +142,7 @@
                             ]
                         },
                         "visualization-only": {
+                            "outputPath": "static-visualization-only",
                             "budgets": [
                                 {
                                     "type": "initial",
@@ -200,6 +201,7 @@
                             ]
                         },
                         "visualization-only-dev": {
+                            "outputPath": "static-visualization-only",
                             "buildOptimizer": false,
                             "optimization": {
                                 "scripts": false,

--- a/angular.json
+++ b/angular.json
@@ -198,6 +198,24 @@
                                     "with": "erdblick_app/environments/environment.visualization-only.ts"
                                 }
                             ]
+                        },
+                        "visualization-only-dev": {
+                            "buildOptimizer": false,
+                            "optimization": {
+                                "scripts": false,
+                                "styles": false,
+                                "fonts": false
+                            },
+                            "vendorChunk": true,
+                            "extractLicenses": false,
+                            "sourceMap": true,
+                            "namedChunks": true,
+                            "fileReplacements": [
+                                {
+                                    "replace": "erdblick_app/environments/environment.ts",
+                                    "with": "erdblick_app/environments/environment.visualization-only.ts"
+                                }
+                            ]
                         }
                     },
                     "defaultConfiguration": "production"
@@ -213,6 +231,9 @@
                         },
                         "visualization-only": {
                             "browserTarget": "erdblick:build:visualization-only"
+                        },
+                        "visualization-only-dev": {
+                            "browserTarget": "erdblick:build:visualization-only-dev"
                         }
                     },
                     "defaultConfiguration": "development"

--- a/build-ui.bash
+++ b/build-ui.bash
@@ -8,6 +8,14 @@ if [ -z $SOURCE_LOC ]; then
   exit 1
 fi
 
+# Validate build mode if provided
+if [ ! -z "$BUILD_MODE" ]; then
+  if [[ "$BUILD_MODE" != "default" && "$BUILD_MODE" != "visualization-only" && "$BUILD_MODE" != "all" ]]; then
+    echo "Invalid build mode. Supported values are: default, visualization-only, all"
+    exit 1
+  fi
+fi
+
 echo "Using source dir @ $SOURCE_LOC."
 cd "$SOURCE_LOC" || exit 1
 
@@ -18,7 +26,16 @@ echo "Building Angular distribution files."
 npm run lint
 
 # Determine which build mode to use
-if [[ -n "$NG_DEVELOP" && "$BUILD_MODE" == "visualization-only" ]]; then
+if [[ "$BUILD_MODE" == "all" ]]; then
+  echo "Building all configurations..."
+  if [[ -n "$NG_DEVELOP" ]]; then
+    npm run build -- -c development
+    npm run build -- -c visualization-only-dev
+  else
+    npm run build
+    npm run build -- -c visualization-only
+  fi
+elif [[ -n "$NG_DEVELOP" && "$BUILD_MODE" == "visualization-only" ]]; then
   echo "Building in visualization-only development mode."
   npm run build -- -c visualization-only-dev
 elif [[ -n "$NG_DEVELOP" ]]; then

--- a/build-ui.bash
+++ b/build-ui.bash
@@ -18,7 +18,10 @@ echo "Building Angular distribution files."
 npm run lint
 
 # Determine which build mode to use
-if [[ -n "$NG_DEVELOP" ]]; then
+if [[ -n "$NG_DEVELOP" && "$BUILD_MODE" == "visualization-only" ]]; then
+  echo "Building in visualization-only development mode."
+  npm run build -- -c visualization-only-dev
+elif [[ -n "$NG_DEVELOP" ]]; then
   npm run build -- -c development
 elif [[ "$BUILD_MODE" == "visualization-only" ]]; then
   echo "Building in visualization-only mode."

--- a/build-ui.bash
+++ b/build-ui.bash
@@ -2,6 +2,7 @@
 set -e
 
 SOURCE_LOC=$1
+BUILD_MODE=$2  # New parameter for build mode
 if [ -z $SOURCE_LOC ]; then
   echo "No source location supplied."
   exit 1
@@ -15,8 +16,13 @@ npm install
 
 echo "Building Angular distribution files."
 npm run lint
+
+# Determine which build mode to use
 if [[ -n "$NG_DEVELOP" ]]; then
   npm run build -- -c development
+elif [[ "$BUILD_MODE" == "visualization-only" ]]; then
+  echo "Building in visualization-only mode."
+  npm run build -- -c visualization-only
 else
   npm run build
 fi

--- a/config/styles/default-style.yaml
+++ b/config/styles/default-style.yaml
@@ -3,10 +3,13 @@ version: 1.0
 options:
   - label: Show Meshes/Polygons
     id: showMesh
+    default: false
   - label: Show Points
     id: showPoint
+    default: true
   - label: Show Lines
     id: showLine
+    default: true
 
 rules:
   # Normal styles

--- a/erdblick_app/app/app-mode.service.ts
+++ b/erdblick_app/app/app-mode.service.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@angular/core';
+import { environment } from '../environments/environment';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AppModeService {
+  readonly isVisualizationOnly = environment.visualizationOnly;
+}

--- a/erdblick_app/app/app.component.ts
+++ b/erdblick_app/app/app.component.ts
@@ -6,18 +6,19 @@ import {MapService} from "./map.service";
 import {ParametersService} from "./parameters.service";
 import {StyleService} from "./style.service";
 import {filter} from "rxjs";
+import {AppModeService} from "./app-mode.service";
 
 @Component({
     selector: 'app-root',
     template: `
         <erdblick-view></erdblick-view>
-        <map-panel></map-panel>
+        <map-panel *ngIf="!appModeService.isVisualizationOnly"></map-panel>
         <p-toast position="top-center" key="tc"></p-toast>
-        <search-panel></search-panel>
-        <inspection-panel></inspection-panel>
-        <pref-components></pref-components>
-        <coordinates-panel></coordinates-panel>
-        <stats-dialog></stats-dialog>
+        <search-panel *ngIf="!appModeService.isVisualizationOnly"></search-panel>
+        <inspection-panel *ngIf="!appModeService.isVisualizationOnly"></inspection-panel>
+        <pref-components *ngIf="!appModeService.isVisualizationOnly"></pref-components>
+        <coordinates-panel *ngIf="!appModeService.isVisualizationOnly"></coordinates-panel>
+        <stats-dialog *ngIf="!appModeService.isVisualizationOnly"></stats-dialog>
         <legal-dialog></legal-dialog>
         <div *ngIf="copyright.length" id="copyright-info" (click)="openLegalInfo()">
             {{ copyright }}
@@ -46,6 +47,7 @@ export class AppComponent {
                 private router: Router,
                 private activatedRoute: ActivatedRoute,
                 public mapService: MapService,
+                public appModeService: AppModeService,
                 public parametersService: ParametersService) {
         this.httpClient.get('./bundle/VERSION', {responseType: 'text'}).subscribe(
             data => {

--- a/erdblick_app/app/map.service.ts
+++ b/erdblick_app/app/map.service.ts
@@ -14,7 +14,6 @@ import {PointMergeService} from "./pointmerge.service";
 import {KeyboardService} from "./keyboard.service";
 import * as uuid from 'uuid';
 import {Color} from "./cesium";
-import {AppModeService} from "./app-mode.service";
 
 /** Expected structure of a LayerInfoItem's coverage entry. */
 export interface CoverageRectItem extends Record<string, any> {
@@ -127,20 +126,19 @@ export class MapService {
                 private sidePanelService: SidePanelService,
                 private messageService: InfoMessageService,
                 private pointMergeService: PointMergeService,
-                private keyboardService: KeyboardService,
-                private appModeService: AppModeService)
+                private keyboardService: KeyboardService)
     {
         this.loadedTileLayers = new Map();
         this.visualizedTileLayers = new Map();
         this.currentFetch = null;
         this.currentViewport = {
-            orientation: 0,
-            camPosLon: 0,
-            south: 0,
-            west: 0,
-            width: 0,
-            height: 0,
-            camPosLat: 0
+            south: .0,
+            west: .0,
+            width: .0,
+            height: .0,
+            camPosLon: .0,
+            camPosLat: .0,
+            orientation: .0,
         };
         this.currentVisibleTileIds = new Set();
         this.currentHighDetailTileIds = new Set();
@@ -161,8 +159,6 @@ export class MapService {
         // Unique client ID which ensures that tile fetch requests from this map-service
         // are de-duplicated on the mapget server.
         this.clientId = uuid.v4();
-
-        this.keyboardService.registerShortcut('o', this.statsDialogKeyPressed.bind(this), true);
     }
 
     public async initialize() {
@@ -892,10 +888,5 @@ export class MapService {
     private clearAllLegalInfo(): void {
         this.legalInformationPerMap.clear();
         this.legalInformationUpdated.next(true);
-    }
-
-    private statsDialogKeyPressed() {
-        this.statsDialogVisible = true;
-        this.statsDialogNeedsUpdate.next();
     }
 }

--- a/erdblick_app/app/map.service.ts
+++ b/erdblick_app/app/map.service.ts
@@ -14,6 +14,7 @@ import {PointMergeService} from "./pointmerge.service";
 import {KeyboardService} from "./keyboard.service";
 import * as uuid from 'uuid';
 import {Color} from "./cesium";
+import {AppModeService} from "./app-mode.service";
 
 /** Expected structure of a LayerInfoItem's coverage entry. */
 export interface CoverageRectItem extends Record<string, any> {
@@ -126,19 +127,20 @@ export class MapService {
                 private sidePanelService: SidePanelService,
                 private messageService: InfoMessageService,
                 private pointMergeService: PointMergeService,
-                private keyboardService: KeyboardService)
+                private keyboardService: KeyboardService,
+                private appModeService: AppModeService)
     {
         this.loadedTileLayers = new Map();
         this.visualizedTileLayers = new Map();
         this.currentFetch = null;
         this.currentViewport = {
-            south: .0,
-            west: .0,
-            width: .0,
-            height: .0,
-            camPosLon: .0,
-            camPosLat: .0,
-            orientation: .0,
+            orientation: 0,
+            camPosLon: 0,
+            south: 0,
+            west: 0,
+            width: 0,
+            height: 0,
+            camPosLat: 0
         };
         this.currentVisibleTileIds = new Set();
         this.currentHighDetailTileIds = new Set();
@@ -159,6 +161,8 @@ export class MapService {
         // Unique client ID which ensures that tile fetch requests from this map-service
         // are de-duplicated on the mapget server.
         this.clientId = uuid.v4();
+
+        this.keyboardService.registerShortcut('o', this.statsDialogKeyPressed.bind(this), true);
     }
 
     public async initialize() {
@@ -888,5 +892,10 @@ export class MapService {
     private clearAllLegalInfo(): void {
         this.legalInformationPerMap.clear();
         this.legalInformationUpdated.next(true);
+    }
+
+    private statsDialogKeyPressed() {
+        this.statsDialogVisible = true;
+        this.statsDialogNeedsUpdate.next();
     }
 }

--- a/erdblick_app/app/parameters.service.ts
+++ b/erdblick_app/app/parameters.service.ts
@@ -193,6 +193,8 @@ const erdblickParameters: Record<string, ParameterDescriptor> = {
 };
 
 /** Set of parameter keys allowed in visualization-only mode */
+// TODO: Reflect this in the parameter descriptors, instead
+// of having a separate set.
 const VISUALIZATION_ONLY_ALLOWED = new Set([
     'heading',
     'pitch',

--- a/erdblick_app/app/parameters.service.ts
+++ b/erdblick_app/app/parameters.service.ts
@@ -3,6 +3,7 @@ import {BehaviorSubject} from "rxjs";
 import {Cartesian3, Cartographic, CesiumMath, Camera} from "./cesium";
 import {Params} from "@angular/router";
 import {SelectedSourceData} from "./inspection.service";
+import { AppModeService } from "./app-mode.service";
 
 export const MAX_NUM_TILES_TO_LOAD = 2048;
 export const MAX_NUM_TILES_TO_VISUALIZE = 512;
@@ -191,12 +192,29 @@ const erdblickParameters: Record<string, ParameterDescriptor> = {
     }
 };
 
+/** Set of parameter keys allowed in visualization-only mode */
+const VISUALIZATION_ONLY_ALLOWED = new Set([
+    'heading',
+    'pitch',
+    'roll',
+    'lon',
+    'lat',
+    'alt',
+    'osm',
+    'osmOpacity',
+    'tilesLoadLimit',
+    'tilesVisualizeLimit'
+]);
+
 @Injectable({providedIn: 'root'})
 export class ParametersService {
 
     private _replaceUrl: boolean = true;
     parameters: BehaviorSubject<ErdblickParameters>;
     initialQueryParamsSet: boolean = false;
+
+    // Store filtered parameter descriptors based on mode
+    private parameterDescriptors: Record<string, ParameterDescriptor>;
 
     cameraViewData: BehaviorSubject<{destination: Cartesian3, orientation: {heading: number, pitch: number, roll: number}}> =
         new BehaviorSubject<{destination: Cartesian3, orientation: {heading: number, pitch: number, roll: number}}>({
@@ -220,7 +238,15 @@ export class ParametersService {
 
     legalInfoDialogVisible: boolean = false;
 
-    constructor() {
+    constructor(appModeService: AppModeService) {
+        // Filter parameter descriptors based on mode
+        this.parameterDescriptors = appModeService.isVisualizationOnly
+            ? Object.fromEntries(
+                Object.entries(erdblickParameters)
+                    .filter(([key]) => VISUALIZATION_ONLY_ALLOWED.has(key))
+              )
+            : erdblickParameters;
+
         this.baseFontSize = parseFloat(window.getComputedStyle(document.documentElement).fontSize);
 
         let parameters = this.loadSavedParameters();
@@ -292,6 +318,11 @@ export class ParametersService {
     }
 
     setInitialStyles(styles: Record<string, StyleParameters>) {
+        // In visualization-only mode, ignore style updates
+        if (Object.keys(this.parameterDescriptors).length !== Object.keys(erdblickParameters).length) {
+            return;
+        }
+
         // Only set styles, if there are no configured values yet.
         if (!Object.entries(this.p().styles).length) {
             return;
@@ -406,20 +437,33 @@ export class ParametersService {
         if (parameters) {
             parsedParameters = JSON.parse(parameters);
         }
-        return Object.keys(erdblickParameters).reduce((acc, key: string) => {
-            const descriptor = erdblickParameters[key];
-            let value = parsedParameters!.hasOwnProperty(key) ? parsedParameters[key] : descriptor.default;
-            acc[key] = descriptor.validator(value) ? value : descriptor.default;
+
+        // First create an object with all default values from the full parameter set
+        let defaultParameters = Object.keys(erdblickParameters).reduce((acc, key: string) => {
+            acc[key] = erdblickParameters[key].default;
             return acc;
         }, {} as any);
+
+        // Then override with valid values from the filtered parameter descriptors
+        Object.keys(this.parameterDescriptors).forEach(key => {
+            const descriptor = this.parameterDescriptors[key];
+            if (parsedParameters.hasOwnProperty(key)) {
+                const value = parsedParameters[key];
+                if (descriptor.validator(value)) {
+                    defaultParameters[key] = value;
+                }
+            }
+        });
+
+        return defaultParameters;
     }
 
     parseAndApplyQueryParams(params: Params) {
         let currentParameters = this.p();
         let updatedParameters: ErdblickParameters = { ...currentParameters };
 
-        Object.keys(erdblickParameters).forEach(key => {
-            const descriptor = erdblickParameters[key];
+        Object.keys(this.parameterDescriptors).forEach(key => {
+            const descriptor = this.parameterDescriptors[key];
             if (params.hasOwnProperty(key)) {
                 try {
                     const value = descriptor.converter(params[key]);
@@ -444,7 +488,6 @@ export class ParametersService {
             });
         }
 
-        // Update BehaviorSubject with the new parameters
         this.parameters.next(updatedParameters);
         this.initialQueryParamsSet = true;
     }
@@ -485,8 +528,8 @@ export class ParametersService {
     }
 
     isUrlParameter(name: string) {
-        if (erdblickParameters.hasOwnProperty(name)) {
-            return erdblickParameters[name].urlParam;
+        if (this.parameterDescriptors.hasOwnProperty(name)) {
+            return this.parameterDescriptors[name].urlParam;
         }
         return false;
     }

--- a/erdblick_app/app/view.component.ts
+++ b/erdblick_app/app/view.component.ts
@@ -30,6 +30,7 @@ import {KeyboardService} from "./keyboard.service";
 import {coreLib} from "./wasm";
 import {MenuItem} from "primeng/api";
 import {RightClickMenuService} from "./rightclickmenu.service";
+import {AppModeService} from "./app-mode.service";
 
 // Redeclare window with extended interface
 declare let window: DebugWindow;
@@ -38,8 +39,8 @@ declare let window: DebugWindow;
     selector: 'erdblick-view',
     template: `
         <div #viewer id="mapViewContainer" class="mapviewer-renderlayer" style="z-index: 0"></div>
-        <p-contextMenu [target]="viewer" [model]="menuItems" (onHide)="onContextMenuHide()" />
-        <sourcedatadialog></sourcedatadialog>
+        <p-contextMenu *ngIf="!appModeService.isVisualizationOnly" [target]="viewer" [model]="menuItems" (onHide)="onContextMenuHide()" />
+        <sourcedatadialog *ngIf="!appModeService.isVisualizationOnly"></sourcedatadialog>
     `,
     styles: [`
         @media only screen and (max-width: 56em) {
@@ -76,6 +77,7 @@ export class ErdblickViewComponent implements AfterViewInit {
                 public inspectionService: InspectionService,
                 public keyboardService: KeyboardService,
                 public menuService: RightClickMenuService,
+                public appModeService: AppModeService,
                 public coordinatesService: CoordinatesService) {
 
         this.mapService.tileVisualizationTopic.subscribe((tileVis: TileVisualization) => {
@@ -134,6 +136,58 @@ export class ErdblickViewComponent implements AfterViewInit {
         this.openStreetMapLayer.alpha = 0.3;
         this.mouseHandler = new ScreenSpaceEventHandler(this.viewer.scene.canvas);
         this.cameraIsMoving = false;
+
+        // Only register interactive events when not in visualization-only mode
+        if (!this.appModeService.isVisualizationOnly) {
+            this.registerInteractiveEvents();
+        }
+
+        this.viewer.camera.percentageChanged = 0.1;
+        this.viewer.camera.changed.addEventListener(() => {
+            this.parameterService.setCameraState(this.viewer.camera);
+            this.updateViewport();
+        });
+        this.viewer.camera.moveStart.addEventListener(() => {
+            this.cameraIsMoving = true;
+        });
+        this.viewer.camera.moveEnd.addEventListener(() => {
+            this.cameraIsMoving = false;
+        });
+        this.viewer.scene.globe.baseColor = new Color(0.1, 0.1, 0.1, 1);
+
+        // Remove fullscreen button as unnecessary
+        this.viewer.fullscreenButton.destroy();
+
+        this.parameterService.cameraViewData.pipe(distinctUntilChanged()).subscribe(cameraData => {
+            this.viewer.camera.setView({
+                destination: cameraData.destination,
+                orientation: cameraData.orientation
+            });
+            this.updateViewport();
+        });
+
+        this.parameterService.parameters.subscribe(parameters => {
+            if (this.openStreetMapLayer) {
+                this.openStreetMapLayer.show = parameters.osm;
+                this.updateOpenStreetMapLayer(parameters.osmOpacity / 100);
+            }
+            if (parameters.marker && parameters.markedPosition.length == 2) {
+                this.addMarker(Cartesian3.fromDegrees(
+                    parameters.markedPosition[0],
+                    parameters.markedPosition[1],
+                    parameters.markedPosition.length > 2 ? parameters.markedPosition[2] : 0.0));
+            } else if (this.marker !== null) {
+                this.viewer.entities.remove(this.marker);
+                this.marker = null;
+            }
+        });
+
+        // Add debug API that can be easily called from browser's debug console
+        window.ebDebug = new ErdblickDebugApi(this.mapService, this.parameterService, this);
+    }
+
+    private registerInteractiveEvents() {
+        if (!this.mouseHandler) return;
 
         this.mouseHandler.setInputAction((movement: any) => {
             const position = movement.position;
@@ -215,112 +269,6 @@ export class ErdblickViewComponent implements AfterViewInit {
                 false,
                 coreLib.HighlightMode.HOVER_HIGHLIGHT).then();
         }, ScreenSpaceEventType.MOUSE_MOVE);
-
-        // Add a handler for camera movement.
-        this.viewer.camera.percentageChanged = 0.1;
-        this.viewer.camera.changed.addEventListener(() => {
-            this.parameterService.setCameraState(this.viewer.camera);
-            this.updateViewport();
-        });
-        this.viewer.camera.moveStart.addEventListener(() => {
-            this.cameraIsMoving = true;
-        });
-        this.viewer.camera.moveEnd.addEventListener(() => {
-            this.cameraIsMoving = false;
-        });
-        this.viewer.scene.globe.baseColor = new Color(0.1, 0.1, 0.1, 1);
-
-        // Remove fullscreen button as unnecessary
-        this.viewer.fullscreenButton.destroy();
-
-        this.parameterService.cameraViewData.pipe(distinctUntilChanged()).subscribe(cameraData => {
-            this.viewer.camera.setView({
-                destination: cameraData.destination,
-                orientation: cameraData.orientation
-            });
-            this.updateViewport();
-        });
-
-        this.parameterService.parameters.subscribe(parameters => {
-            if (this.openStreetMapLayer) {
-                this.openStreetMapLayer.show = parameters.osm;
-                this.updateOpenStreetMapLayer(parameters.osmOpacity / 100);
-            }
-            if (parameters.marker && parameters.markedPosition.length == 2) {
-                this.addMarker(Cartesian3.fromDegrees(
-                    Number(parameters.markedPosition[0]),
-                    Number(parameters.markedPosition[1]))
-                );
-            } else {
-                if (this.marker) {
-                    this.viewer.entities.remove(this.marker);
-                }
-            }
-        });
-
-        // Add debug API that can be easily called from browser's debug console
-        window.ebDebug = new ErdblickDebugApi(this.mapService, this.parameterService, this);
-
-        this.viewer.scene.primitives.add(this.featureSearchService.visualization);
-        this.featureSearchService.visualizationChanged.subscribe(_ => {
-            this.renderFeatureSearchResultTree(this.mapService.zoomLevel.getValue());
-            this.viewer.scene.requestRender();
-        });
-
-        this.mapService.zoomLevel.pipe(distinctUntilChanged()).subscribe(level => {
-            this.renderFeatureSearchResultTree(level);
-        });
-
-        this.jumpService.markedPosition.subscribe(position => {
-            if (position.length >= 2) {
-                this.parameterService.setMarkerState(true);
-                this.parameterService.setMarkerPosition(Cartographic.fromDegrees(position[1], position[0]));
-            }
-        });
-
-        this.inspectionService.originAndNormalForFeatureZoom.subscribe(values => {
-            const [origin, normal] = values;
-            const direction = Cartesian3.subtract(normal, new Cartesian3(), new Cartesian3());
-            const endPoint = Cartesian3.add(origin, direction, new Cartesian3());
-            Cartesian3.normalize(direction, direction);
-            Cartesian3.negate(direction, direction);
-            const up = this.viewer.scene.globe.ellipsoid.geodeticSurfaceNormal(endPoint, new Cartesian3());
-            const right = Cartesian3.cross(direction, up, new Cartesian3());
-            Cartesian3.normalize(right, right);
-            const cameraUp = Cartesian3.cross(right, direction, new Cartesian3());
-            Cartesian3.normalize(cameraUp, cameraUp);
-            this.viewer.camera.flyTo({
-                destination: endPoint,
-                orientation: {
-                    direction: direction,
-                    up: cameraUp,
-                }
-            });
-        });
-
-        this.keyboardService.registerShortcut('q', this.zoomIn.bind(this), true);
-        this.keyboardService.registerShortcut('e', this.zoomOut.bind(this), true);
-        this.keyboardService.registerShortcut('w', this.moveUp.bind(this), true);
-        this.keyboardService.registerShortcut('a', this.moveLeft.bind(this), true);
-        this.keyboardService.registerShortcut('s', this.moveDown.bind(this), true);
-        this.keyboardService.registerShortcut('d', this.moveRight.bind(this), true);
-        this.keyboardService.registerShortcut('r', this.resetOrientation.bind(this), true);
-
-        // Hide the global loading spinner.
-        const spinner = document.getElementById('global-spinner-container');
-        if (spinner) {
-            spinner.style.display = 'none';
-        }
-
-        this.menuService.tileOutline.subscribe(entity => {
-            if (entity) {
-                this.tileOutlineEntity = this.viewer.entities.add(entity);
-                this.viewer.scene.requestRender();
-            } else if (this.tileOutlineEntity) {
-                this.viewer.entities.remove(this.tileOutlineEntity);
-                this.viewer.scene.requestRender();
-            }
-        });
     }
 
     /**
@@ -406,7 +354,7 @@ export class ErdblickViewComponent implements AfterViewInit {
             }
         });
     }
-    
+
     renderFeatureSearchResultTree(level: number) {
         this.featureSearchService.visualization.removeAll();
         const color = Color.fromCssColorString(this.featureSearchService.pointColor);

--- a/erdblick_app/app/view.component.ts
+++ b/erdblick_app/app/view.component.ts
@@ -113,7 +113,7 @@ export class ErdblickViewComponent implements AfterViewInit {
         });
     }
 
-    ngAfterViewInit() {
+    ngAfterViewInit(): void {
         this.viewer = new Viewer("mapViewContainer",
             {
                 baseLayerPicker: false,
@@ -136,6 +136,23 @@ export class ErdblickViewComponent implements AfterViewInit {
         this.openStreetMapLayer.alpha = 0.3;
         this.mouseHandler = new ScreenSpaceEventHandler(this.viewer.scene.canvas);
         this.cameraIsMoving = false;
+
+        // Add these critical initialization parts BEFORE the interactive events check
+        this.viewer.scene.primitives.add(this.featureSearchService.visualization);
+        this.featureSearchService.visualizationChanged.subscribe(_ => {
+            this.renderFeatureSearchResultTree(this.mapService.zoomLevel.getValue());
+            this.viewer.scene.requestRender();
+        });
+
+        this.mapService.zoomLevel.pipe(distinctUntilChanged()).subscribe(level => {
+            this.renderFeatureSearchResultTree(level);
+        });
+
+        // Hide the global loading spinner.
+        const spinner = document.getElementById('global-spinner-container');
+        if (spinner) {
+            spinner.style.display = 'none';
+        }
 
         // Only register interactive events when not in visualization-only mode
         if (!this.appModeService.isVisualizationOnly) {

--- a/erdblick_app/environments/environment.prod.ts
+++ b/erdblick_app/environments/environment.prod.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: true,
+  visualizationOnly: false
+};

--- a/erdblick_app/environments/environment.ts
+++ b/erdblick_app/environments/environment.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: false,
+  visualizationOnly: false
+};

--- a/erdblick_app/environments/environment.visualization-only.ts
+++ b/erdblick_app/environments/environment.visualization-only.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: true,
+  visualizationOnly: true
+};


### PR DESCRIPTION
**Status**: Usable, but still to be discussed if/how we could make the impl. simpler.

In addition to the default GUI/frontend, this PR introduces a special mode that hides all UI controls and displays only the map visualization — without search, inspection tools, or source/style configuration. This mode is intended for showcasing map content without exposing full functionality for feature interaction or detailed inspection.

TODOs:

- [x] revert map.service.ts changes as don't contrib to the intented improvement
- [x] parameter.service.ts intro a flag/bool in the param descriptor that indicates if the param is used for the visualization-only mode or not instead of this list with plain string keys