### PR TITLE
Add Service Metadata, Map Groups. Change how Groups/Maps activate

### DIFF
--- a/erdblick_app/app/inspection.panel.component.ts
+++ b/erdblick_app/app/inspection.panel.component.ts
@@ -115,18 +115,27 @@ export class InspectionPanelComponent
                 this.reset();
                 const map = this.mapService.maps.getValue().get(selection.mapId);
                 if (map) {
-                    this.layerMenuItems = Array.from(map.layers.values()).filter(item => item.type == "SourceData").map(item => {
-                        return {
-                            label: this.inspectionService.layerNameForSourceDataLayerId(item.layerId),
-                            disabled: item.layerId === selection.layerId,
-                            command: () => {
-                                let sourceData = {...selection};
-                                sourceData.layerId = item.layerId;
-                                sourceData.address = BigInt(0);
-                                this.inspectionService.selectedSourceData.next(sourceData);
-                            },
-                        };
-                    });
+                    // TODO: Fix missing entries for the metadata on tile 0
+                    this.layerMenuItems = Array.from(map.layers.values())
+                        .filter(item => item.type == "SourceData")
+                        .filter(item =>
+                            item.layerId.startsWith("SourceData") // || item.layerId.startsWith("Metadata"))
+                        )
+                        .map(item => {
+                            return {
+                                label: this.inspectionService.layerNameForSourceDataLayerId(
+                                    item.layerId,
+                                    item.layerId.startsWith("Metadata")
+                                ),
+                                disabled: item.layerId === selection.layerId,
+                                command: () => {
+                                    let sourceData = {...selection};
+                                    sourceData.layerId = item.layerId;
+                                    sourceData.address = BigInt(0);
+                                    this.inspectionService.selectedSourceData.next(sourceData);
+                                },
+                            };
+                    }).sort((a, b) => a.label.localeCompare(b.label));
                     this.selectedLayerItem = this.layerMenuItems.filter(item => item.disabled).pop();
                 } else {
                     this.layerMenuItems = [];

--- a/erdblick_app/app/inspection.service.ts
+++ b/erdblick_app/app/inspection.service.ts
@@ -318,6 +318,15 @@ export class InspectionService {
         });
     }
 
+    loadSourceDataInspectionForService(mapId: string) {
+        this.isInspectionPanelVisible = true;
+        this.selectedSourceData.next({
+            tileId: 0,
+            layerId: `${mapId}-Metadata-ServiceModuleDefinition`,
+            mapId: mapId
+        });
+    }
+
     /**
      * Returns a human-readable layer name for a layer id.
      *

--- a/erdblick_app/app/inspection.service.ts
+++ b/erdblick_app/app/inspection.service.ts
@@ -11,6 +11,7 @@ import {Fetch} from "./fetch.model";
 import {Cartesian3} from "./cesium";
 import {InfoMessageService} from "./info.service";
 import {KeyboardService} from "./keyboard.service";
+import {metadata} from "cesium";
 
 
 interface InspectionModelData {
@@ -318,11 +319,11 @@ export class InspectionService {
         });
     }
 
-    loadSourceDataInspectionForService(mapId: string) {
+    loadSourceDataInspectionForService(mapId: string, layerId: string) {
         this.isInspectionPanelVisible = true;
         this.selectedSourceData.next({
             tileId: 0,
-            layerId: `${mapId}-Metadata-ServiceModuleDefinition`,
+            layerId: layerId,
             mapId: mapId
         });
     }
@@ -331,11 +332,18 @@ export class InspectionService {
      * Returns a human-readable layer name for a layer id.
      *
      * @param layerId Layer id to get the name for
+     * @param isMetadata Matches the metadata SourceDataLayers
      */
-    layerNameForSourceDataLayerId(layerId: string) {
-        const match = layerId.match(/^SourceData-([^.]+\.)*(.*)-([\d]+)/);
-        if (match)
-            return `${match[2]}.${match[3]}`;
+    layerNameForSourceDataLayerId(layerId: string, isMetadata: boolean = false) {
+        let match: RegExpMatchArray | null;
+        if (isMetadata) {
+            match = layerId.match(/^Metadata-(.+)-(.+)/);
+        } else {
+            match = layerId.match(/^SourceData-(.+\.)([^.]+)/);
+        }
+        if (match) {
+            return `${match[2]}`.replace('-', '.');
+        }
         return layerId;
     }
 
@@ -357,6 +365,24 @@ export class InspectionService {
             }
         }
         return null;
+    }
+
+    findLayersForMapId(mapId: string, isMetadata: boolean = false) {
+        const map = this.mapService.maps.getValue().get(mapId);
+        if (map) {
+            const prefix = isMetadata ? "Metadata" : "SourceData";
+            const dataLayers = new Set<string>();
+            for (const layer of map.layers.values()) {
+                if (layer.type == "SourceData" && layer.layerId.startsWith(prefix)) {
+                    dataLayers.add(layer.layerId);
+                }
+            }
+            return [...dataLayers].map(layerId => ({
+                id: layerId,
+                name: this.layerNameForSourceDataLayerId(layerId, isMetadata)
+            })).sort((a, b) => a.name.localeCompare(b.name));
+        }
+        return [];
     }
 
     protected readonly InspectionValueType = coreLib.ValueType;

--- a/erdblick_app/app/inspection.service.ts
+++ b/erdblick_app/app/inspection.service.ts
@@ -11,7 +11,6 @@ import {Fetch} from "./fetch.model";
 import {Cartesian3} from "./cesium";
 import {InfoMessageService} from "./info.service";
 import {KeyboardService} from "./keyboard.service";
-import {metadata} from "cesium";
 
 
 interface InspectionModelData {

--- a/erdblick_app/app/map.panel.component.ts
+++ b/erdblick_app/app/map.panel.component.ts
@@ -14,6 +14,7 @@ import {Menu} from "primeng/menu";
 import {KeyboardService} from "./keyboard.service";
 import {EditorService} from "./editor.service";
 import {DataSourcesService} from "./datasources.service";
+import {InspectionService} from "./inspection.service";
 
 
 @Component({
@@ -68,11 +69,20 @@ import {DataSourcesService} from "./datasources.service";
                                     </div>
                                 </div>
                                 <div class="layer-controls">
+                                    <p-button onEnterClick (click)="requestServiceMetadata(mapItem.key)"
+                                              label="" pTooltip="Request service metadata" tooltipPosition="bottom"
+                                              [style]="{'padding-left': '0', 'padding-right': '0'}" tabindex="0">
+                                        <span class="material-icons" style="font-size: 1.2em; margin: 0 auto;">
+                                            data_object
+                                        </span>
+                                    </p-button>
                                     <p-button onEnterClick (click)="toggleTileBorders(mapItem.key, mapLayer.key)"
                                             label="" pTooltip="Toggle tile borders" tooltipPosition="bottom"
                                             [style]="{'padding-left': '0', 'padding-right': '0'}" tabindex="0">
                                         <span class="material-icons"
-                                            style="font-size: 1.2em; margin: 0 auto;">{{ mapLayer.value.tileBorders ? 'select_all' : 'deselect' }}</span>
+                                            style="font-size: 1.2em; margin: 0 auto;">
+                                            {{ mapLayer.value.tileBorders ? 'select_all' : 'deselect' }}
+                                        </span>
                                     </p-button>
                                     <p-button onEnterClick *ngIf="mapLayer.value.coverage.length"
                                             (click)="focus(mapLayer.value.coverage[0], $event)"
@@ -262,6 +272,7 @@ export class MapPanelComponent {
                 public keyboardService: KeyboardService,
                 public editorService: EditorService,
                 public dsService: DataSourcesService,
+                private inspectionService: InspectionService,
                 private sidePanelService: SidePanelService) {
         this.keyboardService.registerShortcut('m', this.showLayerDialog.bind(this), true);
 
@@ -594,5 +605,9 @@ export class MapPanelComponent {
     openDatasources() {
         this.editorService.styleEditorVisible = false;
         this.editorService.datasourcesEditorVisible = true;
+    }
+
+    requestServiceMetadata(mapName: string) {
+        this.inspectionService.loadSourceDataInspectionForService(mapName);
     }
 }

--- a/erdblick_app/app/map.panel.component.ts
+++ b/erdblick_app/app/map.panel.component.ts
@@ -52,45 +52,78 @@ import {InspectionService} from "./inspection.service";
                     <p-accordion *ngIf="mapGroups.size > 1 || !mapGroups.has('ungrouped')" [multiple]="true" styleClass="maps-accordion">
                         <ng-container *ngFor="let group of mapGroups | keyvalue: unordered; let i = index">
                             <p-accordion-panel *ngIf="group.key != 'ungrouped'" [value]="i">
-                                <p-accordion-header>{{ group.key }}</p-accordion-header>
-                                <p-accordion-content>
-                                    <div *ngFor="let mapId of group.value" class="map-container">
-                                        <span class="font-bold white-space-nowrap map-header">
-                                            {{ mapId }}
+                                <p-accordion-header>
+                                    <div style="cursor: pointer; display: inline-block" (click)="$event.stopPropagation(); toggleGroup(group.key)">
+                                        <span>
+                                            <p-checkbox [ngModel]="mapGroupsVisibility.get(group.key)![0]"
+                                                        (click)="$event.stopPropagation()"
+                                                        (ngModelChange)="toggleGroup(group.key)"
+                                                        [binary]="true"
+                                                        [inputId]="group.key"
+                                                        [name]="group.key" tabindex="0"/>
+                                            <label [for]="group.key" style="margin-left: 0.5em; cursor: pointer">
+                                                {{group.key}}
+                                            </label>
                                         </span>
-                                        <div *ngFor="let mapLayer of mapItems.get(mapId)!.layers | keyvalue: unordered">
+                                    </div>
+                                </p-accordion-header>
+                                <p-accordion-content>
+                                    <div *ngFor="let mapItem of group.value" class="map-container">
+                                        <p-menu #metadataMenu [model]="metadataMenusEntries.get(mapItem.mapId)" [popup]="true" appendTo="body" />
+                                        <div class="flex-container">
+                                            <div style="cursor: pointer; display: inline-block" (click)="mapItem.visible = !mapItem.visible; toggleMap(mapItem.mapId)">
+                                                <span>
+                                                    <p-checkbox [(ngModel)]="mapItem.visible"
+                                                                (ngModelChange)="toggleMap(mapItem.mapId)"
+                                                                [binary]="true"
+                                                                [inputId]="mapItem.mapId"
+                                                                [name]="mapItem.mapId" tabindex="0"/>
+                                                    <label [for]="mapItem.mapId" style="margin-left: 0.5em; cursor: pointer">
+                                                        {{removePrefix(mapItem.mapId)}}
+                                                    </label>
+                                                </span>
+                                            </div>
+                                            <div class="map-controls">
+                                                <p-button onEnterClick (click)="metadataMenu.toggle($event)"
+                                                          label="" pTooltip="Request service metadata"
+                                                          tooltipPosition="bottom"
+                                                          [style]="{'padding-left': '0', 'padding-right': '0'}"
+                                                          tabindex="0">
+                                                    <span class="material-icons"
+                                                          style="font-size: 1.2em; margin: 0 auto;">
+                                                        data_object
+                                                    </span>
+                                                </p-button>
+                                            </div>
+                                        </div>
+                                        <div *ngFor="let mapLayer of mapItem.layers | keyvalue: unordered">
                                             <div *ngIf="mapLayer.value.type != 'SourceData'" class="flex-container">
                                                 <div class="font-bold white-space-nowrap"
                                                      style="margin-left: 0.5em; display: flex; align-items: center;">
-                                    <span onEnterClick class="material-icons" style="font-size: 1.5em; cursor: pointer"
-                                          tabindex="0"
-                                          (click)="showLayersToggleMenu($event, mapId, mapLayer.key)">more_vert</span>
-                                                    <div style="cursor: pointer; display: inline-block" (click)="mapLayer.value.visible = !mapLayer.value.visible; toggleLayer(mapId, mapLayer.key)">
-                                        <span>
-                                            <p-checkbox [(ngModel)]="mapLayer.value.visible"
-                                                        (ngModelChange)="toggleLayer(mapId, mapLayer.key)"
-                                                        [binary]="true"
-                                                        [inputId]="mapLayer.key"
-                                                        [name]="mapLayer.key" tabindex="0"/>
-                                            <label [for]="mapLayer.key" style="margin-left: 0.5em; cursor: pointer">{{mapLayer.key}}</label>
-                                        </span>
+                                                    <span onEnterClick class="material-icons" style="font-size: 1.5em; cursor: pointer" 
+                                                          tabindex="0" (click)="showLayersToggleMenu($event, mapItem.mapId, mapLayer.key)">
+                                                        more_vert
+                                                    </span>
+                                                    <div style="cursor: pointer; display: inline-block" 
+                                                         (click)="mapLayer.value.visible = !mapLayer.value.visible; toggleLayer(mapItem.mapId, mapLayer.key)">
+                                                        <span>
+                                                            <p-checkbox [(ngModel)]="mapLayer.value.visible"
+                                                                        (ngModelChange)="toggleLayer(mapItem.mapId, mapLayer.key)"
+                                                                        [binary]="true"
+                                                                        [inputId]="mapLayer.key"
+                                                                        [name]="mapLayer.key" tabindex="0"/>
+                                                            <label [for]="mapLayer.key" style="margin-left: 0.5em; cursor: pointer">{{mapLayer.key}}</label>
+                                                        </span>
                                                     </div>
                                                 </div>
                                                 <div class="layer-controls">
-                                                    <p-button onEnterClick (click)="requestServiceMetadata(mapId)"
-                                                              label="" pTooltip="Request service metadata" tooltipPosition="bottom"
-                                                              [style]="{'padding-left': '0', 'padding-right': '0'}" tabindex="0">
-                                        <span class="material-icons" style="font-size: 1.2em; margin: 0 auto;">
-                                            data_object
-                                        </span>
-                                                    </p-button>
-                                                    <p-button onEnterClick (click)="toggleTileBorders(mapId, mapLayer.key)"
+                                                    <p-button onEnterClick (click)="toggleTileBorders(mapItem.mapId, mapLayer.key)"
                                                               label="" pTooltip="Toggle tile borders" tooltipPosition="bottom"
                                                               [style]="{'padding-left': '0', 'padding-right': '0'}" tabindex="0">
-                                        <span class="material-icons"
-                                              style="font-size: 1.2em; margin: 0 auto;">
-                                            {{ mapLayer.value.tileBorders ? 'select_all' : 'deselect' }}
-                                        </span>
+                                                    <span class="material-icons"
+                                                          style="font-size: 1.2em; margin: 0 auto;">
+                                                        {{ mapLayer.value.tileBorders ? 'select_all' : 'deselect' }}
+                                                    </span>
                                                     </p-button>
                                                     <p-button onEnterClick *ngIf="mapLayer.value.coverage.length"
                                                               (click)="focus(mapLayer.value.coverage[0], $event)"
@@ -99,7 +132,7 @@ import {InspectionService} from "./inspection.service";
                                                         <span class="material-icons" style="font-size: 1.2em; margin: 0 auto;">loupe</span>
                                                     </p-button>
                                                     <p-inputNumber [(ngModel)]="mapLayer.value.level"
-                                                                   (ngModelChange)="onLayerLevelChanged($event, mapId, mapLayer.key)"
+                                                                   (ngModelChange)="onLayerLevelChanged($event, mapItem.mapId, mapLayer.key)"
                                                                    [showButtons]="true" [min]="0" [max]="15"
                                                                    buttonLayout="horizontal" spinnerMode="horizontal" inputId="horizontal"
                                                                    decrementButtonClass="p-button-secondary"
@@ -118,21 +151,39 @@ import {InspectionService} from "./inspection.service";
                         </ng-container>
                     </p-accordion>
                     <ng-container *ngIf="mapGroups.has('ungrouped')">
-                        <div *ngFor="let mapId of mapGroups.get('ungrouped')" class="map-container">
-                            <span class="font-bold white-space-nowrap map-header">
-                                {{ mapId }}
-                            </span>
-                            <div *ngFor="let mapLayer of mapItems.get(mapId)!.layers | keyvalue: unordered">
+                        <div *ngFor="let mapItem of mapGroups.get('ungrouped')" class="map-container">
+                            <p-menu #metadataMenu [model]="metadataMenusEntries.get(mapItem.mapId)" [popup]="true" appendTo="body" />
+                            <div class="flex-container">
+                                <div style="cursor: pointer; display: inline-block" (click)="mapItem.visible = !mapItem.visible; toggleMap(mapItem.mapId)">
+                                    <span>
+                                        <p-checkbox (click)="toggleMap(mapItem.mapId)"
+                                                    [binary]="true"
+                                                    [inputId]="mapItem.mapId"
+                                                    [name]="mapItem.mapId" tabindex="0"/>
+                                        <label [for]="mapItem.mapId" style="margin-left: 0.5em; cursor: pointer">{{mapItem.mapId}}</label>
+                                    </span>
+                                </div>
+                                <div class="map-controls">
+                                    <p-button onEnterClick (click)="metadataMenu.toggle($event)" label="" pTooltip="Request service metadata"
+                                              tooltipPosition="bottom" [style]="{'padding-left': '0', 'padding-right': '0'}" tabindex="0">
+                                        <span class="material-icons"
+                                              style="font-size: 1.2em; margin: 0 auto;">
+                                            data_object
+                                        </span>
+                                    </p-button>
+                                </div>
+                            </div>
+                            <div *ngFor="let mapLayer of mapItem.layers | keyvalue: unordered">
                                 <div *ngIf="mapLayer.value.type != 'SourceData'" class="flex-container">
                                     <div class="font-bold white-space-nowrap"
                                          style="margin-left: 0.5em; display: flex; align-items: center;">
                                     <span onEnterClick class="material-icons" style="font-size: 1.5em; cursor: pointer"
                                           tabindex="0"
-                                          (click)="showLayersToggleMenu($event, mapId, mapLayer.key)">more_vert</span>
-                                        <div style="cursor: pointer; display: inline-block" (click)="mapLayer.value.visible = !mapLayer.value.visible; toggleLayer(mapId, mapLayer.key)">
+                                          (click)="showLayersToggleMenu($event, mapItem.mapId, mapLayer.key)">more_vert</span>
+                                        <div style="cursor: pointer; display: inline-block" (click)="mapLayer.value.visible = !mapLayer.value.visible; toggleLayer(mapItem.mapId, mapLayer.key)">
                                         <span>
                                             <p-checkbox [(ngModel)]="mapLayer.value.visible"
-                                                        (ngModelChange)="toggleLayer(mapId, mapLayer.key)"
+                                                        (ngModelChange)="toggleLayer(mapItem.mapId, mapLayer.key)"
                                                         [binary]="true"
                                                         [inputId]="mapLayer.key"
                                                         [name]="mapLayer.key" tabindex="0"/>
@@ -141,14 +192,7 @@ import {InspectionService} from "./inspection.service";
                                         </div>
                                     </div>
                                     <div class="layer-controls">
-                                        <p-button onEnterClick (click)="requestServiceMetadata(mapId)"
-                                                  label="" pTooltip="Request service metadata" tooltipPosition="bottom"
-                                                  [style]="{'padding-left': '0', 'padding-right': '0'}" tabindex="0">
-                                        <span class="material-icons" style="font-size: 1.2em; margin: 0 auto;">
-                                            data_object
-                                        </span>
-                                        </p-button>
-                                        <p-button onEnterClick (click)="toggleTileBorders(mapId, mapLayer.key)"
+                                        <p-button onEnterClick (click)="toggleTileBorders(mapItem.mapId, mapLayer.key)"
                                                   label="" pTooltip="Toggle tile borders" tooltipPosition="bottom"
                                                   [style]="{'padding-left': '0', 'padding-right': '0'}" tabindex="0">
                                         <span class="material-icons"
@@ -163,7 +207,7 @@ import {InspectionService} from "./inspection.service";
                                             <span class="material-icons" style="font-size: 1.2em; margin: 0 auto;">loupe</span>
                                         </p-button>
                                         <p-inputNumber [(ngModel)]="mapLayer.value.level"
-                                                       (ngModelChange)="onLayerLevelChanged($event, mapId, mapLayer.key)"
+                                                       (ngModelChange)="onLayerLevelChanged($event, mapItem.mapId, mapLayer.key)"
                                                        [showButtons]="true" [min]="0" [max]="15"
                                                        buttonLayout="horizontal" spinnerMode="horizontal" inputId="horizontal"
                                                        decrementButtonClass="p-button-secondary"
@@ -324,7 +368,7 @@ import {InspectionService} from "./inspection.service";
 export class MapPanelComponent {
     layerDialogVisible: boolean = false;
     warningDialogVisible: boolean = false;
-    mapItems: Map<string, MapInfoItem> = new Map<string, MapInfoItem>();
+    // mapItems: Map<string, MapInfoItem> = new Map<string, MapInfoItem>();
     editedStyleSourceSubscription: Subscription = new Subscription();
     savedStyleSourceSubscription: Subscription = new Subscription();
     sourceWasModified: boolean = false;
@@ -338,6 +382,9 @@ export class MapPanelComponent {
     @ViewChild('styleUploader') styleUploader: FileUpload | undefined;
     @ViewChild('editorDialog') editorDialog: Dialog | undefined;
     @ViewChild('mapLayerDialog') mapLayerDialog: Dialog | undefined;
+
+    mapGroupsVisibility: Map<string, [boolean, boolean]> = new Map<string, [boolean, boolean]>();
+    metadataMenusEntries: Map<string, {label: string, command: () => void }[]> = new Map();
 
     constructor(public mapService: MapService,
                 private messageService: InfoMessageService,
@@ -354,9 +401,27 @@ export class MapPanelComponent {
             this.osmEnabled = parameters.osm;
             this.osmOpacityValue = parameters.osmOpacity;
         });
-        this.mapService.maps.subscribe(
-            mapItems => this.mapItems = mapItems
-        );
+        // TODO: Use parameter service to store the state of the groups
+        this.mapService.mapGroups.subscribe(mapGroups => {
+            for (const [groupId, mapItems] of mapGroups.entries()) {
+                if (groupId !== "ungrouped") {
+                    const groupVisibility = mapItems.some(mapItem => mapItem.visible);
+                    const mapsVisibility = mapItems.every(mapItem => mapItem.visible);
+                    this.mapGroupsVisibility.set(groupId, [groupVisibility, mapsVisibility]);
+                }
+                mapItems.forEach(mapItem => this.metadataMenusEntries.set(
+                    mapItem.mapId,
+                    this.inspectionService.findLayersForMapId(mapItem.mapId, true)
+                        .map(layer => {
+                            return {
+                                label: layer.name,
+                                command: () =>
+                                    this.inspectionService.loadSourceDataInspectionForService(mapItem.mapId, layer.id)
+                            }
+                    })
+                ));
+            }
+        });
         this.sidePanelService.observable().subscribe(activePanel => {
             if (activePanel != SidePanelState.MAPS) {
                 this.layerDialogVisible = false;
@@ -468,9 +533,9 @@ export class MapPanelComponent {
             {
                 label: 'Toggle All off but This',
                 command: () => {
-                    if (this.mapItems.has(mapName)) {
-                        for (const id of this.mapItems.get(mapName)!.layers.keys()!) {
-                            this.mapItems.get(mapName)!.layers.get(id)!.visible = id == layerName;
+                    if (this.mapService.maps.getValue().has(mapName)) {
+                        for (const id of this.mapService.maps.getValue().get(mapName)!.layers.keys()!) {
+                            this.mapService.maps.getValue().get(mapName)!.layers.get(id)!.visible = id == layerName;
                             this.toggleLayer(mapName, layerName);
                         }
                     }
@@ -479,9 +544,9 @@ export class MapPanelComponent {
             {
                 label: 'Toggle All on but This',
                 command: () => {
-                    if (this.mapItems.has(mapName)) {
-                        for (const id of this.mapItems.get(mapName)!.layers.keys()!) {
-                            this.mapItems.get(mapName)!.layers.get(id)!.visible = id != layerName;
+                    if (this.mapService.maps.getValue().has(mapName)) {
+                        for (const id of this.mapService.maps.getValue().get(mapName)!.layers.keys()!) {
+                            this.mapService.maps.getValue().get(mapName)!.layers.get(id)!.visible = id != layerName;
                             this.toggleLayer(mapName, layerName);
                         }
                     }
@@ -490,9 +555,9 @@ export class MapPanelComponent {
             {
                 label: 'Toggle All Off',
                 command: () => {
-                    if (this.mapItems.has(mapName)) {
-                        for (const id of this.mapItems.get(mapName)!.layers.keys()!) {
-                            this.mapItems.get(mapName)!.layers.get(id)!.visible = false;
+                    if (this.mapService.maps.getValue().has(mapName)) {
+                        for (const id of this.mapService.maps.getValue().get(mapName)!.layers.keys()!) {
+                            this.mapService.maps.getValue().get(mapName)!.layers.get(id)!.visible = false;
                             this.toggleLayer(mapName, layerName);
                         }
                     }
@@ -501,9 +566,9 @@ export class MapPanelComponent {
             {
                 label: 'Toggle All On',
                 command: () => {
-                    if (this.mapItems.has(mapName)) {
-                        for (const id of this.mapItems.get(mapName)!.layers.keys()!) {
-                            this.mapItems.get(mapName)!.layers.get(id)!.visible = true;
+                    if (this.mapService.maps.getValue().has(mapName)) {
+                        for (const id of this.mapService.maps.getValue().get(mapName)!.layers.keys()!) {
+                            this.mapService.maps.getValue().get(mapName)!.layers.get(id)!.visible = true;
                             this.toggleLayer(mapName, layerName);
                         }
                     }
@@ -681,7 +746,50 @@ export class MapPanelComponent {
         this.editorService.datasourcesEditorVisible = true;
     }
 
-    requestServiceMetadata(mapName: string) {
-        this.inspectionService.loadSourceDataInspectionForService(mapName);
+    removePrefix(mapId: string) {
+        if (mapId.includes('/')) {
+            const mapIdParts = mapId.split('/');
+            return mapIdParts.slice(1).join('/');
+        }
+        return mapId;
+    }
+
+    toggleMap(mapId: string, groupId: string = "") {
+        if (!mapId) {
+            return;
+        }
+        if (groupId && groupId !== "ungrouped") {
+            const state = this.mapGroupsVisibility.has(groupId) && this.mapGroupsVisibility.get(groupId)![0];
+            this.mapService.toggleMapLayerVisibility(mapId, "", state)
+            return;
+        }
+        if (mapId.includes('/')) {
+            const groupId = mapId.split('/')[0];
+            if (this.mapService.mapGroups.getValue().has(groupId)) {
+                const mapItems = this.mapService.mapGroups.getValue().get(groupId)!;
+                const groupVisibility = mapItems.some(mapItem => mapItem.visible);
+                const mapsVisibility = mapItems.every(mapItem => mapItem.visible);
+                this.mapGroupsVisibility.set(groupId, [groupVisibility, mapsVisibility]);
+            }
+        }
+        this.mapService.toggleMapLayerVisibility(mapId);
+    }
+
+    toggleGroup(groupId: string) {
+        if (!groupId || groupId === 'ungrouped') {
+            return;
+        }
+        if (!this.mapGroupsVisibility.has(groupId)) {
+            return;
+        }
+        if (!this.mapService.mapGroups.getValue().has(groupId)) {
+            return;
+        }
+        const currentState = this.mapGroupsVisibility.get(groupId)!;
+        currentState[0] = !currentState[0];
+        this.mapGroupsVisibility.set(groupId, [currentState[0], currentState[0]]);
+        this.mapService.mapGroups.getValue().get(groupId)!.forEach(mapItem => {
+            this.toggleMap(mapItem.mapId, groupId);
+        });
     }
 }

--- a/erdblick_app/app/map.panel.component.ts
+++ b/erdblick_app/app/map.panel.component.ts
@@ -368,7 +368,6 @@ import {InspectionService} from "./inspection.service";
 export class MapPanelComponent {
     layerDialogVisible: boolean = false;
     warningDialogVisible: boolean = false;
-    // mapItems: Map<string, MapInfoItem> = new Map<string, MapInfoItem>();
     editedStyleSourceSubscription: Subscription = new Subscription();
     savedStyleSourceSubscription: Subscription = new Subscription();
     sourceWasModified: boolean = false;

--- a/erdblick_app/app/map.panel.component.ts
+++ b/erdblick_app/app/map.panel.component.ts
@@ -156,7 +156,8 @@ import {InspectionService} from "./inspection.service";
                             <div class="flex-container">
                                 <div style="cursor: pointer; display: inline-block" (click)="mapItem.visible = !mapItem.visible; toggleMap(mapItem.mapId)">
                                     <span>
-                                        <p-checkbox (click)="toggleMap(mapItem.mapId)"
+                                        <p-checkbox [(ngModel)]="mapItem.visible"
+                                                    (ngModelChange)="toggleMap(mapItem.mapId)"
                                                     [binary]="true"
                                                     [inputId]="mapItem.mapId"
                                                     [name]="mapItem.mapId" tabindex="0"/>

--- a/erdblick_app/app/map.service.ts
+++ b/erdblick_app/app/map.service.ts
@@ -13,7 +13,6 @@ import {MAX_ZOOM_LEVEL} from "./feature.search.service";
 import {PointMergeService} from "./pointmerge.service";
 import {KeyboardService} from "./keyboard.service";
 import * as uuid from 'uuid';
-import {Color} from "./cesium";
 
 /** Expected structure of a LayerInfoItem's coverage entry. */
 export interface CoverageRectItem extends Record<string, any> {
@@ -85,7 +84,7 @@ function featureSetsEqual(rhs: FeatureWrapper[], lhs: FeatureWrapper[]) {
 export class MapService {
 
     public maps: BehaviorSubject<Map<string, MapInfoItem>> = new BehaviorSubject<Map<string, MapInfoItem>>(new Map<string, MapInfoItem>());
-    public mapGroups: BehaviorSubject<Map<string, Array<string>>> = new BehaviorSubject<Map<string, Array<string>>>(new Map<string, Array<string>>());
+    public mapGroups: BehaviorSubject<Map<string, Array<MapInfoItem>>> = new BehaviorSubject<Map<string, Array<MapInfoItem>>>(new Map<string, Array<MapInfoItem>>());
     public loadedTileLayers: Map<string, FeatureTile>;
     public legalInformationPerMap = new Map<string, Set<string>>();
     public legalInformationUpdated = new Subject<boolean>();
@@ -190,22 +189,64 @@ export class MapService {
         this.tileParser = new coreLib.TileLayerParser();
 
         this.maps.subscribe(mapItems => {
-            const groups = new Map<string, Array<string>>();
-            const ungrouped: Array<string> = []; // Maintain this group as the last inserted item for ordering simplicity
-            for (const mapId of mapItems.keys()) {
+            const initRun = this.mapGroups.getValue().size == 0;
+            const groups = new Map<string, Array<MapInfoItem>>();
+            const ungrouped: Array<MapInfoItem> = []; // Maintain this group as the last inserted item to simplify ordering
+            let firstGroup = "";
+            for (const [mapId, mapItem] of mapItems) {
                 if (mapId.includes('/')) {
                     const prefix = mapId.split('/')[0];
                     if (groups.has(prefix)) {
-                        groups.get(prefix)!.push(mapId);
+                        groups.get(prefix)!.push(mapItem);
                         continue;
                     }
-                    groups.set(prefix, [mapId]);
+                    groups.set(prefix, [mapItem]);
+                    if (!firstGroup) {
+                        firstGroup = prefix;
+                    }
                 } else {
-                    ungrouped.push(mapId);
+                    ungrouped.push(mapItem);
+                }
+            }
+            if (!initRun) {
+                for (const [groupId, mapItems] of groups) {
+                    if (!this.mapGroups.getValue().has(groupId)) {
+                        for (const mapItem of mapItems) {
+                            mapItem.visible = true;
+                            this.toggleMapLayerVisibility(mapItem.mapId);
+                        }
+                    } else {
+                        const prevGroup = this.mapGroups.getValue().get(groupId)!;
+                        for (const mapItem of mapItems) {
+                            if (!prevGroup.find(prev => prev.mapId === mapItem.mapId)) {
+                                mapItem.visible = true;
+                                this.toggleMapLayerVisibility(mapItem.mapId);
+                            }
+                        }
+                    }
+                }
+            } else if (firstGroup) {
+                for (const mapItem of groups.get(firstGroup)!) {
+                    mapItem.visible = true;
+                    this.toggleMapLayerVisibility(mapItem.mapId);
                 }
             }
             if (ungrouped.length > 0) {
-                groups.set("ungrouped", ungrouped)
+                if (!initRun) {
+                    if (this.mapGroups.getValue().has("ungrouped")) {
+                        const prevUngrouped = this.mapGroups.getValue().get("ungrouped")!;
+                        for (const mapItem of ungrouped) {
+                            if (!prevUngrouped.find(prev => prev.mapId === mapItem.mapId)) {
+                                mapItem.visible = true;
+                                this.toggleMapLayerVisibility(mapItem.mapId);
+                            }
+                        }
+                    }
+                } else if (!firstGroup) {
+                    ungrouped[0].visible = true;
+                    this.toggleMapLayerVisibility(ungrouped[0].mapId);
+                }
+                groups.set("ungrouped", ungrouped);
             }
             this.mapGroups.next(groups);
         });
@@ -343,7 +384,7 @@ export class MapService {
                             layers.set(layerId, layerInfo);
                         }
                         mapInfo.layers = layers;
-                        mapInfo.visible = true;
+                        mapInfo.visible = false;
                         return [mapInfo.mapId, mapInfo];
                     }));
                     this.maps.next(maps);
@@ -370,26 +411,45 @@ export class MapService {
         return false;
     }
 
-    toggleMapLayerVisibility(mapId: string, layerId: string) {
+    toggleMapLayerVisibility(mapId: string, layerId: string = "", state: boolean | undefined = undefined) {
         const mapItem = this.maps.getValue().get(mapId);
         if (mapItem === undefined) {
             return;
         }
         if (layerId) {
             const layer = mapItem.layers.get(layerId);
-            if (layer !== undefined) {
-                this.parameterService.setMapLayerConfig(mapId, layerId, layer.level, layer.visible, layer.tileBorders);
-                if (!layer.visible) {
-                    this.clearSelectionForLayer(mapId, layerId);
+            if (layer === undefined) {
+                return;
+            }
+            if (state !== undefined) {
+                layer.visible = state;
+            }
+            this.parameterService.setMapLayerConfig(mapId, layerId, layer.level, layer.visible, layer.tileBorders);
+            if (!layer.visible) {
+                this.clearSelectionForLayer(mapId, layerId);
+            }
+            mapItem.visible = mapItem.layers.values().some(layer => layer.visible);
+        } else {
+            if (state !== undefined) {
+                mapItem.visible = state;
+            }
+            const params: {mapId: string, layerId: string, level: number, visible: boolean, tileBorders: boolean}[] = []
+            for (const [_, layer] of mapItem.layers) {
+                if (layer.type !== "SourceData") {
+                    layer.visible = mapItem.visible;
+                    params.push({
+                        mapId: mapItem.mapId,
+                        layerId: layer.layerId,
+                        level: layer.level,
+                        visible: layer.visible,
+                        tileBorders: layer.tileBorders
+                    });
+                    if (!layer.visible) {
+                        this.clearSelectionForLayer(mapId, layer.layerId);
+                    }
                 }
             }
-        } else {
-            mapItem.layers.forEach(layer => {
-                this.parameterService.setMapLayerConfig(mapId, layer.layerId, layer.level, mapItem.visible, layer.tileBorders);
-                if (!mapItem.visible) {
-                    this.clearSelectionForLayer(mapId, layer.layerId);
-                }
-            });
+            this.parameterService.setMapConfig(params);
         }
         this.update().then();
     }

--- a/erdblick_app/app/parameters.service.ts
+++ b/erdblick_app/app/parameters.service.ts
@@ -242,8 +242,6 @@ export class ParametersService {
 
     legalInfoDialogVisible: boolean = false;
 
-    sourceMetadataEntries: BehaviorSubject<Map<string, Array<string>>> = new BehaviorSubject(new Map<string, Array<string>>());
-
     constructor(appModeService: AppModeService) {
         // Filter parameter descriptors based on mode
         this.parameterDescriptors = appModeService.isVisualizationOnly

--- a/erdblick_app/app/parameters.service.ts
+++ b/erdblick_app/app/parameters.service.ts
@@ -242,6 +242,8 @@ export class ParametersService {
 
     legalInfoDialogVisible: boolean = false;
 
+    sourceMetadataEntries: BehaviorSubject<Map<string, Array<string>>> = new BehaviorSubject(new Map<string, Array<string>>());
+
     constructor(appModeService: AppModeService) {
         // Filter parameter descriptors based on mode
         this.parameterDescriptors = appModeService.isVisualizationOnly
@@ -400,6 +402,21 @@ export class ParametersService {
         } else if (visible) {
             this.p().layers.push([mapLayerName, level, visible, tileBorders]);
         }
+        this.parameters.next(this.p());
+    }
+
+    setMapConfig(layerParams: {mapId: string, layerId: string, level: number, visible: boolean, tileBorders: boolean}[]) {
+        layerParams.forEach(params => {
+            let mapLayerName = params.mapId+"/"+params.layerId;
+            let conf = this.p().layers.find(val => val[0] == mapLayerName);
+            if (conf !== undefined) {
+                conf[1] = params.level;
+                conf[2] = params.visible;
+                conf[3] = params.tileBorders;
+            } else if (params.visible) {
+                this.p().layers.push([mapLayerName, params.level, params.visible, params.tileBorders]);
+            }
+        })
         this.parameters.next(this.p());
     }
 

--- a/erdblick_app/app/sourcedataselection.dialog.component.ts
+++ b/erdblick_app/app/sourcedataselection.dialog.component.ts
@@ -223,7 +223,7 @@ export class SourceDataLayerSelectionDialogComponent {
             this.mapIds = mapIds.sort((a, b) => a.name.localeCompare(b.name));
             for (let i = 0; i < this.mapIds.length; i++) {
                 const id = this.mapIds[i].id as string;
-                const layers = this.findLayersForMapId(id);
+                const layers = this.inspectionService.findLayersForMapId(id);
                 this.mapIds[i]["disabled"] = !layers.length;
                 this.sourceDataLayersPerMapId.set(id, layers);
             }
@@ -244,23 +244,6 @@ export class SourceDataLayerSelectionDialogComponent {
             }
         }
         this.menuService.tileOutline.next(entity);
-    }
-
-    findLayersForMapId(mapId: string) {
-        const map = this.mapService.maps.getValue().get(mapId);
-        if (map) {
-            const dataLayers = new Set<string>();
-            for (const layer of map.layers.values()) {
-                if (layer.type == "SourceData") {
-                    dataLayers.add(layer.layerId);
-                }
-            }
-            return [...dataLayers].map(layerId => ({
-                id: layerId,
-                name: this.inspectionService.layerNameForSourceDataLayerId(layerId)
-            }));
-        }
-        return [];
     }
 
     onMapIdChange(mapId: SourceDataDropdownOption) {

--- a/erdblick_app/styles.scss
+++ b/erdblick_app/styles.scss
@@ -389,6 +389,7 @@ body {
     line-height: 0;
 
     textarea {
+      padding-top: 0.75em;
       width: 100% !important;
       transition: all 0.3s;
       resize: none;
@@ -1269,13 +1270,13 @@ body {
         height: 100%;
         border-radius: 0;
         border: none;
+        padding-top: 1em;
       }
 
       textarea.single-line {
         width: 100% !important;
         height: 100%;
-        padding-left: 2em;
-        padding-top: 0.75em;
+        padding-left: 1em;
         border-radius: 0;
         border: none;
         white-space: nowrap;

--- a/erdblick_app/styles.scss
+++ b/erdblick_app/styles.scss
@@ -558,7 +558,15 @@ body {
   }
 
   .p-fieldset {
-    padding: 0.5em 0.75em 0.5em 0.75em;
+    padding: 0;
+
+    .p-accordionheader {
+      padding: 0.5em 1em 0.5em 1em;
+    }
+
+    .p-accordioncontent-content {
+      padding: 0;
+    }
   }
 }
 
@@ -597,7 +605,7 @@ body {
     display: flex;
     align-items: center;
     gap: 1em;
-    margin-top: 0.25em;
+    margin: 0.5em 0.75em;
 
     button {
       width: 2em;
@@ -673,6 +681,7 @@ body {
 
     .p-fieldset-legend {
       padding: 0.5em;
+      margin-left: 0.5em;
       border: 1px solid #dee2e6;
       color: #343a40;
       background: #f8f9fa;
@@ -692,12 +701,12 @@ body {
   }
 
   .maps-container {
-    margin-top: 0.25em;
-    padding-right: 0.75em;
-    margin-right: -0.75em;
+    &:last-child {
+      border: none;
+    }
 
     .map-container {
-      margin-top: 0.5em;
+      padding: 0.5em 1em 0.5em 1em;
 
       .map-header {
         font-size: 0.9em;
@@ -710,9 +719,10 @@ body {
   }
 
   .styles-container {
-    margin-top: 0.25em;
-    padding-right: 0.75em;
-    margin-right: -0.75em;
+    padding: 0.5em 1em 0.5em 1em;
+    //margin-top: 0.25em;
+    //padding-right: 0.75em;
+    //margin-right: -0.75em;
 
     .rotated-icon {
       transform: rotate(-90deg);
@@ -790,6 +800,20 @@ body {
 
       .p-inputnumber-increment-button {
         border-radius: 0 var(--p-button-border-radius) var(--p-button-border-radius) 0;
+      }
+    }
+
+    .map-controls {
+      display: flex;
+      gap: 0.5em;
+      width: 4em;
+      justify-content: flex-end;
+      transition: opacity 0s, visibility 0s;
+
+      button {
+        width: 2em;
+        height: 2em;
+        box-shadow: none;
       }
     }
 


### PR DESCRIPTION
**Goal**: enable users to inspect Service Metadata, combine maps into groups by prefix and load new maps in activated state.

**Scope**: 
* MapService
* MapPanelComponent
* InspectionPanelComponent
* InspectionService

**Deliverables**:
* Menu to select and load metadata in the inspection panel
* Collapsible map groups in the maps section

**How to test**:
1. Build as usual.
2. Make sure that the service provides metadata.
3. Configure to serve map IDs with certain prefixes.
4. Serve.

**TODOs**:
- [ ] Fix missing entries in the inspection panel dropdown.