### PR TITLE
Fix Duplicate/False Diagnostics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ message("Building for ${CMAKE_SYSTEM_NAME}.")
 if (NOT TARGET mapget)
   FetchContent_Declare(mapget
     GIT_REPOSITORY "https://github.com/Klebert-Engineering/mapget"
-    GIT_TAG        "release/2025.3.1"
+    GIT_TAG        "fix-zlib-build"
     GIT_SHALLOW    ON)
   FetchContent_MakeAvailable(mapget)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ message("Building for ${CMAKE_SYSTEM_NAME}.")
 if (NOT TARGET mapget)
   FetchContent_Declare(mapget
     GIT_REPOSITORY "https://github.com/Klebert-Engineering/mapget"
-    GIT_TAG        "fix-zlib-build"
+    GIT_TAG        "release/2025.3.1"
     GIT_SHALLOW    ON)
   FetchContent_MakeAvailable(mapget)
 endif()

--- a/erdblick_app/app/feature.search.component.ts
+++ b/erdblick_app/app/feature.search.component.ts
@@ -85,7 +85,7 @@ import {SearchPanelComponent} from "./search.panel.component";
                                             <li>
                                                 <div>
                                                     <span>{{ message.message }}</span>
-                                                    <div><span>Here: </span><code style="width: 100%;" [innerHTML]="searchService.currentQuery | highlightRegion:message.location.offset:message.location.size:25"></code></div>
+                                                    <div><span>Here: </span><code style="width: 100%;" [innerHTML]="message.query | highlightRegion:message.location.offset:message.location.size:25"></code></div>
                                                 </div>
                                                 <p-button size="small" label="Fix" *ngIf="message.fix" (onClick)="onApplyFix(message)" />
                                             </li>
@@ -207,14 +207,16 @@ export class FeatureSearchComponent {
 
     pauseSearch() {
         if (this.canPauseStopSearch) {
-            if (this.isSearchPaused) {
+            if (this.isSearchPaused && this.searchService.currentSearchGroup) {
+                const query = this.searchService.currentSearchGroup?.query;
+                console.log(`Resuming query '${query}'`);
                 this.isSearchPaused = false;
-                this.searchService.run(this.searchService.currentQuery, true);
-                return;
+                this.searchService.run(query, true);
+            } else {
+                this.searchService.pause();
+                this.listbox.options = this.searchService.searchResults;
+                this.isSearchPaused = true;
             }
-            this.searchService.pause();
-            this.listbox.options = this.searchService.searchResults;
-            this.isSearchPaused = true;
         }
     }
 

--- a/erdblick_app/app/feature.search.component.ts
+++ b/erdblick_app/app/feature.search.component.ts
@@ -165,6 +165,8 @@ export class FeatureSearchComponent {
         });
         this.searchService.diagnosticsMessages.subscribe(value => {
             this.diagnostics = value;
+            if (this.diagnostics.length > 0 && this.results.length === 0)
+                this.resultPanelIndex = 'diagnostics';
         })
     }
 

--- a/erdblick_app/app/feature.search.component.ts
+++ b/erdblick_app/app/feature.search.component.ts
@@ -163,11 +163,13 @@ export class FeatureSearchComponent {
                 this.searchResultReady();
             }
         });
+        this.searchService.diagnosticsMessages.subscribe(value => {
+            this.diagnostics = value;
+        })
     }
 
     searchResultReady() {
         const results = this.searchService.searchResults;
-        const diagnostics = this.searchService.diagnosticsResults.slice(0, 25);
         const traces = this.searchService.traceResults;
         const errors = this.searchService.errors;
 
@@ -181,31 +183,15 @@ export class FeatureSearchComponent {
                 Array.from(errors).join('\n'))
 
         } else if (results.length == 0) {
-            if (diagnostics.length > 0)
+            if (this.diagnostics.length > 0)
                 this.resultPanelIndex = 'diagnostics';
             else if (traces.length > 0)
                 this.resultPanelIndex = 'traces';
         }
 
-        this.diagnostics = this.deduplicateDiagnosticMessages(diagnostics);
         this.traces = traces
         this.results = results;
     }
-
-    deduplicateDiagnosticMessages(list: Array<DiagnosticsMessage>) {
-        const seen = new Set<string>();
-        return list.filter(msg => {
-            const key = [
-                msg.message,
-                msg.location.offset,
-                msg.location.size,
-                msg.fix ?? ''
-            ].join('|');
-            if (seen.has(key)) return false;
-            seen.add(key);
-            return true;
-        });
-    };
 
     selectResult(event: any) {
         if (event.value && event.value.mapId && event.value.featureId) {

--- a/erdblick_app/app/feature.search.service.ts
+++ b/erdblick_app/app/feature.search.service.ts
@@ -209,8 +209,6 @@ class FeatureSearchQuadTree {
 
 @Injectable({providedIn: 'root'})
 export class FeatureSearchService {
-    currentQuery: string = ""
-
     workers: Array<Worker> = []
     workQueue: Array<WorkerTask> = [];
     cachedWorkQueue: Array<WorkerTask> = [];
@@ -435,7 +433,6 @@ export class FeatureSearchService {
 
     clear() {
         this.stop();
-        this.currentQuery = "";
         this.resultTree = new FeatureSearchQuadTree();
         this.visualization.removeAll();
         this.visualizationPositions = [];

--- a/erdblick_app/app/feature.search.service.ts
+++ b/erdblick_app/app/feature.search.service.ts
@@ -1,10 +1,11 @@
 import {Injectable} from "@angular/core";
 import {Subject} from "rxjs";
 import {MapService} from "./map.service";
-import {CompletionCandidate, CompletionCandidatesForTile, CompletionWorkerTask, DiagnosticsMessage, SearchResultForTile, SearchResultPosition, SearchWorkerTask, TraceResult, WorkerResult, WorkerTask} from "./featurefilter.worker";
+import {CompletionCandidate, CompletionCandidatesForTile, CompletionWorkerTask, DiagnosticsMessage, DiagnosticsResultsForTile, DiagnosticsWorkerTask, SearchResultForTile, SearchResultPosition, SearchWorkerTask, TraceResult, WorkerResult, WorkerTask} from "./featurefilter.worker";
 import {BillboardCollection, Cartographic, Cartesian3, Rectangle} from "./cesium";
 import {FeatureTile} from "./features.model";
 import {coreLib, uint8ArrayFromWasm} from "./wasm";
+import {JobGroup, JobGroupManager} from "./job-group";
 
 export const MAX_ZOOM_LEVEL = 15;
 
@@ -214,6 +215,11 @@ export class FeatureSearchService {
     workQueue: Array<WorkerTask> = [];
     cachedWorkQueue: Array<WorkerTask> = [];
 
+    jobGroupManager: JobGroupManager = new JobGroupManager();
+    currentSearchGroup: JobGroup | null = null;
+    taskIdCounter: number = 0;
+    taskGruoupIdCounter: number = 0;
+
     resultTree: FeatureSearchQuadTree = new FeatureSearchQuadTree();
     visualization: BillboardCollection = new BillboardCollection();
     visualizationPositions: Array<Cartesian3> = [];
@@ -229,7 +235,10 @@ export class FeatureSearchService {
     pinGraphicsByTier: Map<number, string> = new Map<number, string>;
     searchResults: Array<any> = [];
     traceResults: Array<any> = [];
-    diagnosticsResults: Array<DiagnosticsMessage> = [];
+
+    diagnosticsMessages: Subject<DiagnosticsMessage[]> = new Subject<DiagnosticsMessage[]>();
+    diagnosticsMessageLimit: number = 25;
+    private diagnosticsMessagesList: DiagnosticsMessage[] = [];
 
     completionPending: Subject<boolean> = new Subject<boolean>();
     completionCandidates: Subject<CompletionCandidate[]> = new Subject<CompletionCandidate[]>();
@@ -267,12 +276,22 @@ export class FeatureSearchService {
             });
             this.workers.push(worker);
             worker.onmessage = (event: MessageEvent<WorkerResult>) => {
-                switch (event.data.type) {
+                const result = event.data;
+
+                // Notify the job-group if the task has an id
+                if (result.taskId) {
+                    this.jobGroupManager.completeTask(result.taskId, result);
+                }
+
+                switch (result.type) {
                     case 'SearchResultForTile':
-                        this.addSearchResult(event.data as SearchResultForTile);
+                        this.addSearchResult(result as SearchResultForTile);
                         break;
                     case 'CompletionCandidatesForTile':
-                        this.addCompletionCandidates(event.data as CompletionCandidatesForTile);
+                        this.addCompletionCandidates(result as CompletionCandidatesForTile);
+                        break;
+                    case 'DiagnosticsResultsForTile':
+                        this.addDiagnostics(result as DiagnosticsResultsForTile);
                         break;
                 }
 
@@ -337,12 +356,21 @@ export class FeatureSearchService {
             this.clear();
             this.startTime = Date.now();
         }
+
         this.currentQuery = query;
+        this.currentSearchGroup = this.jobGroupManager.createGroup('search', query, this.generateTaskGroupId());
+
+        // Set up completion callback to trigger diagnostics after
+        // all tasks of the group are done.
+        this.currentSearchGroup.onComplete((group: JobGroup) => {
+            this.startDiagnosticsForCompletedSearch(group.query);
+        });
 
         const tileParser = this.mapService.tileParser;
-
-        function makeTask(tile: FeatureTile): SearchWorkerTask {
-            return {
+        const searchGroup = this.currentSearchGroup;
+        const makeTask = (tile: FeatureTile): SearchWorkerTask => {
+            const taskId = this.generateTaskId();
+            const task: SearchWorkerTask = {
                 type: 'SearchWorkerTask',
                 tileId: tile.tileId,
                 tileBlob: tile.tileFeatureLayerBlob as Uint8Array,
@@ -353,22 +381,30 @@ export class FeatureSearchService {
                 dataSourceInfo: uint8ArrayFromWasm((buf) => {
                     tileParser?.getDataSourceInfo(buf, tile.mapName)
                 })!,
-                nodeId: tile.nodeId
-            }
-        }
+                nodeId: tile.nodeId,
+                taskId: taskId,
+                groupId: searchGroup.id
+            };
+
+            this.jobGroupManager.addTaskToGroup(searchGroup.id, taskId, task);
+
+            return task;
+        };
 
         // Fill up work queue and start processing.
         // TODO: What if we move / change the viewport during the search?
         if (!this.cachedWorkQueue.length) {
-            this.workQueue = this.workQueue.concat(this.mapService.getPrioritisedTiles().map(makeTask));
-            this.totalTiles = this.workQueue.length;
+            let tasks = this.mapService.getPrioritisedTiles().map(makeTask);
+
+            this.workQueue = this.workQueue.concat(tasks);
+            this.totalTiles += tasks.length;
             this.isFeatureSearchActive.next(true);
         } else {
             this.workQueue = [...this.cachedWorkQueue];
             this.cachedWorkQueue = [];
         }
         if (this.totalTiles == 0) {
-            this.totalTiles = this.workQueue.length;
+            this.totalTiles = this.getTasksOfType('SearchWorkerTask').length;
         }
 
         this.runWorkers();
@@ -411,7 +447,8 @@ export class FeatureSearchService {
         this.progress.next(0);
         this.searchResults = [];
         this.traceResults = [];
-        this.diagnosticsResults = [];
+        this.diagnosticsMessagesList = [];
+        this.diagnosticsMessages.next([]);
         this.isFeatureSearchActive.next(false);
         this.totalFeatureCount = 0;
         this.startTime = 0;
@@ -422,6 +459,60 @@ export class FeatureSearchService {
         this.completionCandidateList = [];
         this.completionPending.next(false);
         this.completionCandidates.next([]);
+        this.jobGroupManager.clearCompleted();
+        this.currentSearchGroup = null;
+    }
+
+    /// Generate a new task id
+    private generateTaskId(): string {
+        return `task_${Date.now()}_${++this.taskIdCounter}`;
+    }
+
+    /// Generate a new task-group id
+    private generateTaskGroupId(): string {
+        return `group_${Date.now()}_${++this.taskGruoupIdCounter}`;
+    }
+
+    private startDiagnosticsForCompletedSearch(query: string) {
+        if (!this.currentSearchGroup) {
+            return;
+        }
+
+        const diagnosticsGroup = this.jobGroupManager.createGroup('diagnostics', query, this.generateTaskGroupId());
+
+        const tileParser = this.mapService.tileParser;
+        const makeDiagnosticsTask = (tile: FeatureTile): DiagnosticsWorkerTask => {
+            const taskId = this.generateTaskId();
+            const task: DiagnosticsWorkerTask = {
+                type: 'DiagnosticsWorkerTask',
+                blob: tile.tileFeatureLayerBlob as Uint8Array,
+                fieldDictBlob: uint8ArrayFromWasm((buf) => {
+                    tileParser?.getFieldDict(buf, tile.nodeId)
+                })!,
+                query: query,
+                dataSourceInfo: uint8ArrayFromWasm((buf) => {
+                    tileParser?.getDataSourceInfo(buf, tile.mapName)
+                })!,
+                nodeId: tile.nodeId,
+                diagnostics: Array.from(this.currentSearchGroup!.getDiagnostics()),
+                taskId: taskId,
+                groupId: diagnosticsGroup.id,
+            };
+
+            this.jobGroupManager.addTaskToGroup(diagnosticsGroup.id, taskId, task);
+
+            return task;
+        };
+
+        const diagTasks = this.mapService.getPrioritisedTiles().map(makeDiagnosticsTask);
+        this.workQueue = this.workQueue.concat(diagTasks);
+        this.runWorkers();
+    }
+
+    private getTasksOfType(type: string) {
+        return this.workQueue.filter((task: WorkerTask) => {
+            return task.type === type;
+        })
     }
 
     private clearTasksOfType(type: string) {
@@ -440,11 +531,15 @@ export class FeatureSearchService {
         // Remove all pending completion tasks
         this.clearTasksOfType('CompletionWorkerTask');
 
+        // Create completion job group
+        const completionGroup = this.jobGroupManager.createGroup('completion', query, this.generateTaskGroupId());
+
         // Build one task per tile
         const tileParser = this.mapService.tileParser;
         const limit = this.completionCandidateLimit;
-        function makeTask(tile: FeatureTile): CompletionWorkerTask {
-            return {
+        const makeTask = (tile: FeatureTile): CompletionWorkerTask => {
+            const taskId = this.generateTaskId();
+            const task: CompletionWorkerTask = {
                 type: 'CompletionWorkerTask',
                 blob: tile.tileFeatureLayerBlob as Uint8Array,
                 fieldDictBlob: uint8ArrayFromWasm((buf) => {
@@ -457,8 +552,14 @@ export class FeatureSearchService {
                 point: point || query.length,
                 nodeId: tile.nodeId,
                 limit: limit,
-            }
-        }
+                taskId: taskId,
+                groupId: completionGroup.id
+            };
+
+            this.jobGroupManager.addTaskToGroup(completionGroup.id, taskId, task);
+
+            return task;
+        };
 
         this.completionCandidateList = [];
         this.completionPending.next(true);
@@ -481,6 +582,14 @@ export class FeatureSearchService {
         }
     }
 
+    private addDiagnostics(result : DiagnosticsResultsForTile) {
+        this.diagnosticsMessagesList = this.diagnosticsMessagesList
+            .concat(result.messages)
+            .slice(0, this.diagnosticsMessageLimit)
+            .filter((item, index, array) => array.findIndex(other => other.message === item.message && other.location.offset === item.location.offset) === index);
+        this.diagnosticsMessages.next(this.diagnosticsMessagesList);
+    }
+
     private addSearchResult(tileResult: SearchResultForTile) {
         if (tileResult.error) {
             this.errors.add(tileResult.error);
@@ -501,8 +610,10 @@ export class FeatureSearchService {
             })
         }
 
-        // Add diagnostics
-        this.diagnosticsResults = this.diagnosticsResults.concat(tileResult.diagnostics);
+        // Add diagnostics to the current search group
+        if (tileResult.diagnostics && this.currentSearchGroup) {
+            this.currentSearchGroup.addDiagnostics(tileResult.diagnostics);
+        }
 
         // Add visualizations and register the search result.
         if (tileResult.matches.length && tileResult.tileId) {
@@ -535,6 +646,7 @@ export class FeatureSearchService {
     }
 
     private scheduleTask(worker: Worker, task: WorkerTask) {
+        console.debug(`Scheduling task id=${task.taskId || 'null'} group=${task.groupId || 'null'}`);
         worker.postMessage(task);
     }
 

--- a/erdblick_app/app/feature.search.service.ts
+++ b/erdblick_app/app/feature.search.service.ts
@@ -362,6 +362,7 @@ export class FeatureSearchService {
         // Set up completion callback to trigger diagnostics after
         // all tasks of the group are done.
         searchGroup.onComplete((group: JobGroup) => {
+            console.debug(`Search group completed (id: ${group.id}). Collecting diagnostics for query ${group.query}`);
             this.startDiagnosticsForCompletedSearch(group.query);
         });
 
@@ -525,6 +526,11 @@ export class FeatureSearchService {
         // Create completion job group
         const completionGroup = this.jobGroupManager.createGroup('completion', query, this.generateTaskGroupId());
         this.currentCompletionGroup = completionGroup
+        completionGroup.onComplete((group: JobGroup) => {
+            console.debug(`Completion group completed (id: ${group.id}, current: ${this.currentCompletionGroup?.id})`)
+            if (this.currentCompletionGroup?.id === group.id)
+                this.completionPending.next(false);
+        })
 
         // Build one task per tile
         const tileParser = this.mapService.tileParser;

--- a/erdblick_app/app/featurefilter.worker.ts
+++ b/erdblick_app/app/featurefilter.worker.ts
@@ -9,6 +9,8 @@ export interface SearchWorkerTask {
     query: string;
     dataSourceInfo: Uint8Array;
     nodeId: string;
+    taskId?: string;
+    groupId?: string;
 }
 
 export interface CompletionWorkerTask {
@@ -20,6 +22,20 @@ export interface CompletionWorkerTask {
     point: number; // Cursor position to complete at
     nodeId: string;
     limit: number | undefined;
+    taskId?: string;
+    groupId?: string;
+}
+
+export interface DiagnosticsWorkerTask {
+    type: 'DiagnosticsWorkerTask';
+    blob: Uint8Array;
+    fieldDictBlob: Uint8Array;
+    dataSourceInfo: Uint8Array;
+    nodeId: string;
+    query: string;
+    diagnostics: Array<Uint8Array>; // List of diagnostic data
+    taskId?: string;
+    groupId?: string;
 }
 
 export interface SearchResultPosition {
@@ -47,10 +63,12 @@ export interface SearchResultForTile {
     query: string;
     numFeatures: number;
     matches: Array<[string, string, SearchResultPosition]>;  // Array of (MapTileKey, FeatureId, SearchResultPosition)
-    traces: null|Map<string, TraceResult>;
-    diagnostics: Array<DiagnosticsMessage>;
+    traces: Map<string, TraceResult> | null;
+    diagnostics: Uint8Array | null;
     billboardPrimitiveIndices?: Array<number>;  // Used by search service for visualization.
-    error: null|string
+    error: string | null;
+    taskId?: string;
+    groupId?: string;
 }
 
 export interface CompletionCandidate {
@@ -67,10 +85,20 @@ export interface CompletionCandidatesForTile {
     type: 'CompletionCandidatesForTile';
     query: string;
     candidates: CompletionCandidate[];
+    taskId?: string;
+    groupId?: string;
 }
 
-export type WorkerTask = SearchWorkerTask | CompletionWorkerTask;
-export type WorkerResult = SearchResultForTile | CompletionCandidatesForTile;
+export interface DiagnosticsResultsForTile {
+    type: 'DiagnosticsResultsForTile';
+    query: string;
+    messages: DiagnosticsMessage[];
+    taskId?: string;
+    groupId?: string;
+}
+
+export type WorkerTask = SearchWorkerTask | CompletionWorkerTask | DiagnosticsWorkerTask;
+export type WorkerResult = SearchResultForTile | CompletionCandidatesForTile | DiagnosticsResultsForTile;
 
 function processSearch(task: SearchWorkerTask) {
     let postError = (name: string, message: string) => {
@@ -81,8 +109,10 @@ function processSearch(task: SearchWorkerTask) {
             numFeatures: 0,
             matches: [],
             traces: null,
-            diagnostics: [],
-            error: `${name}: ${message}`
+            diagnostics: null,
+            error: `${name}: ${message}`,
+            taskId: task.taskId,
+            groupId: task.groupId
         };
         postMessage(result);
     }
@@ -114,7 +144,9 @@ function processSearch(task: SearchWorkerTask) {
                 matches: queryResult.result,
                 traces: queryResult.traces,
                 diagnostics: queryResult.diagnostics,
-                error: null
+                error: null,
+                taskId: task.taskId,
+                groupId: task.groupId
             };
             postMessage(result);
         }
@@ -163,6 +195,8 @@ function processCompletion(task: CompletionWorkerTask) {
                     hint: item.hint,
                 }
             }),
+            taskId: task.taskId,
+            groupId: task.groupId
         };
         postMessage(result);
     }
@@ -171,14 +205,45 @@ function processCompletion(task: CompletionWorkerTask) {
     }
 }
 
+function processDiagnostics(task: DiagnosticsWorkerTask) {
+    try {
+        // Parse the tile.
+        let parser = new coreLib.TileLayerParser();
+        uint8ArrayToWasm(data => parser.setDataSourceInfo(data), task.dataSourceInfo);
+        uint8ArrayToWasm(data => parser.addFieldDict(data), task.fieldDictBlob);
+        let tile: TileFeatureLayer = uint8ArrayToWasm(data => parser.readTileFeatureLayer(data), task.blob);
+
+        // Get the query results from the tile.
+        let search = new coreLib.FeatureLayerSearch(tile);
+
+        const messages = search.diagnostics(task.query, task.diagnostics);
+
+        search.delete();
+        tile.delete();
+
+        postMessage({
+            type: 'DiagnosticsResultsForTile',
+            query: task.query,
+            messages: messages,
+            taskId: task.taskId,
+            groupId: task.groupId
+        } as DiagnosticsResultsForTile);
+    }
+    catch (exc: any) {
+        console.error("Diagnostics error", exc);
+    }
+}
+
 addEventListener('message', async ({data}) => {
     await initializeLibrary();
 
     let task = (data as WorkerTask);
     switch (task['type']) {
-         case 'SearchWorkerTask':
+        case 'SearchWorkerTask':
             return processSearch(task as SearchWorkerTask);
-         case 'CompletionWorkerTask':
+        case 'CompletionWorkerTask':
             return processCompletion(task as CompletionWorkerTask);
+        case 'DiagnosticsWorkerTask':
+            return processDiagnostics(task as DiagnosticsWorkerTask);
     }
 })

--- a/erdblick_app/app/featurefilter.worker.ts
+++ b/erdblick_app/app/featurefilter.worker.ts
@@ -52,6 +52,7 @@ export interface TraceResult {
 }
 
 export interface DiagnosticsMessage {
+    query: string;
     message: string;
     location: {offset: number, size: number},
     fix: null | string;

--- a/erdblick_app/app/job-group.ts
+++ b/erdblick_app/app/job-group.ts
@@ -1,0 +1,197 @@
+import {WorkerTask} from "./featurefilter.worker";
+
+export type JobGroupType = 'search' | 'completion' | 'diagnostics';
+
+export class JobGroup {
+    readonly id: string;
+    readonly type: JobGroupType;
+    readonly query: string;
+
+    private tasks: Map<string, WorkerTask> = new Map();
+    private completedTasks: Set<string> = new Set();
+    private onCompleteCallback?: (group: JobGroup) => void;
+    private onTaskCompleteCallback?: (taskId: string, result: any) => void;
+    
+    // Runtime/result data
+    private diagnostics: Array<Uint8Array> = [];
+
+    constructor(type: JobGroupType, query: string, id: string) {
+        this.id = id;
+        this.type = type;
+        this.query = query;
+    }
+
+    addTask(taskId: string, task: WorkerTask): void {
+        this.tasks.set(taskId, task);
+    }
+
+    completeTask(taskId: string, result?: any): void {
+        if (this.tasks.has(taskId) && !this.completedTasks.has(taskId)) {
+            this.completedTasks.add(taskId);
+            
+            if (this.onTaskCompleteCallback) {
+                this.onTaskCompleteCallback(taskId, result);
+            }
+            
+            if (this.isComplete() && this.onCompleteCallback) {
+                this.onCompleteCallback(this);
+            }
+        }
+    }
+
+    isComplete(): boolean {
+        return this.tasks.size > 0 && this.completedTasks.size === this.tasks.size;
+    }
+
+    getProgress(): number {
+        if (this.tasks.size === 0) return 0;
+        return (this.completedTasks.size / this.tasks.size) * 100;
+    }
+
+    getTaskCount(): number {
+        return this.tasks.size;
+    }
+
+    getCompletedCount(): number {
+        return this.completedTasks.size;
+    }
+
+    onComplete(callback: (group: JobGroup) => void): void {
+        this.onCompleteCallback = callback;
+        
+        // If already complete, call immediately
+        if (this.isComplete()) {
+            callback(this);
+        }
+    }
+
+    onTaskComplete(callback: (taskId: string, result: any) => void): void {
+        this.onTaskCompleteCallback = callback;
+    }
+
+    getTasks(): ReadonlyMap<string, WorkerTask> {
+        return this.tasks;
+    }
+
+    getCompletedTasks(): ReadonlySet<string> {
+        return this.completedTasks;
+    }
+
+    cancel(): void {
+        this.tasks.clear();
+        this.completedTasks.clear();
+        this.onCompleteCallback = undefined;
+        this.onTaskCompleteCallback = undefined;
+        this.diagnostics.length = 0;
+    }
+
+    addDiagnostics(diagnostics: Uint8Array): void {
+        this.diagnostics.push(diagnostics);
+    }
+
+    getDiagnostics(): ReadonlyArray<Uint8Array> {
+        return this.diagnostics;
+    }
+}
+
+export class JobGroupManager {
+    private groups: Map<string, JobGroup> = new Map();
+    private taskToGroup: Map<string, string> = new Map();
+
+    createGroup(type: JobGroupType, query: string, id: string): JobGroup {
+        const group = new JobGroup(type, query, id);
+        this.groups.set(group.id, group);
+        return group;
+    }
+
+    getGroup(groupId: string): JobGroup | undefined {
+        return this.groups.get(groupId);
+    }
+
+    addTaskToGroup(groupId: string, taskId: string, task: WorkerTask): boolean {
+        const group = this.groups.get(groupId);
+        if (group) {
+            group.addTask(taskId, task);
+            this.taskToGroup.set(taskId, groupId);
+            return true;
+        }
+        return false;
+    }
+
+    completeTask(taskId: string, result?: any): boolean {
+        const groupId = this.taskToGroup.get(taskId);
+        if (groupId) {
+            const group = this.groups.get(groupId);
+            if (group) {
+                group.completeTask(taskId, result);
+                return true;
+            }
+        }
+        return false;
+    }
+
+    getGroupForTask(taskId: string): JobGroup | undefined {
+        const groupId = this.taskToGroup.get(taskId);
+        return groupId ? this.groups.get(groupId) : undefined;
+    }
+
+    removeGroup(groupId: string): void {
+        const group = this.groups.get(groupId);
+        if (group) {
+            // Clean up task mappings
+            for (const taskId of group.getTasks().keys()) {
+                this.taskToGroup.delete(taskId);
+            }
+            group.cancel();
+            this.groups.delete(groupId);
+        }
+    }
+
+    getActiveGroups(): JobGroup[] {
+        return Array.from(this.groups.values()).filter(group => !group.isComplete());
+    }
+
+    getCompletedGroups(): JobGroup[] {
+        return Array.from(this.groups.values()).filter(group => group.isComplete());
+    }
+
+    clearCompleted(): void {
+        const completed = this.getCompletedGroups();
+        for (const group of completed) {
+            this.removeGroup(group.id);
+        }
+    }
+
+    getStats(): {
+        activeGroups: number;
+        completedGroups: number;
+        totalTasks: number;
+        completedTasks: number;
+    } {
+        const active = this.getActiveGroups();
+        const completed = this.getCompletedGroups();
+        
+        const totalTasks = Array.from(this.groups.values())
+            .reduce((sum, group) => sum + group.getTaskCount(), 0);
+        const completedTasks = Array.from(this.groups.values())
+            .reduce((sum, group) => sum + group.getCompletedCount(), 0);
+
+        return {
+            activeGroups: active.length,
+            completedGroups: completed.length,
+            totalTasks,
+            completedTasks
+        };
+    }
+
+    // Convenience methods for search groups
+    getCurrentSearchGroup(): JobGroup | undefined {
+        return Array.from(this.groups.values())
+            .find(group => group.type === 'search' && !group.isComplete());
+    }
+
+    getSearchGroupDiagnostics(groupId: string): ReadonlyArray<Uint8Array> | undefined {
+        const group = this.groups.get(groupId);
+        return group?.type === 'search' ? group.getDiagnostics() : undefined;
+    }
+}

--- a/erdblick_app/app/search.panel.component.ts
+++ b/erdblick_app/app/search.panel.component.ts
@@ -804,9 +804,7 @@ export class SearchPanelComponent implements AfterViewInit {
         if (!query) {
             this.completion.visible = false;
             this.completionItems = [];
-            // Reset the service's currentQuery to allow the same query to work again
-            // TODO: Share the state so we don't have to synchronise it.
-            this.searchService.currentQuery = "";
+            this.searchService.currentCompletionGroup = null;
             return;
         }
 

--- a/libs/core/CMakeLists.txt
+++ b/libs/core/CMakeLists.txt
@@ -35,6 +35,7 @@ set(ERDBLICK_SOURCE_FILES
   src/search.cpp
   src/layer.cpp
 
+  src/cesium-interface/base64.h
   src/cesium-interface/object.cpp
   src/cesium-interface/primitive.cpp
   src/cesium-interface/cesium.cpp

--- a/libs/core/include/erdblick/cesium-interface/object.h
+++ b/libs/core/include/erdblick/cesium-interface/object.h
@@ -65,7 +65,13 @@ struct JsValue
      * Construct an Object as a new JS Float64 TypedArray.
      * @param coordinates Float64 buffer to fill the typed array.
      */
-    static JsValue Float64Array(std::vector<double> const& coordinates);
+    static JsValue Float64Array(std::span<double> const& data);
+
+    /**
+     * Construct a Uint8Array object, filled with the data passed.
+     * @param data Data to pass to the Uint8Array
+     */
+    static JsValue Uint8Array(std::span<std::uint8_t> const& data);
 
     /**
      * Construct an undefined value.
@@ -154,6 +160,11 @@ struct JsValue
      * the mock version.
      */
     [[nodiscard]] uint32_t size() const;
+
+    /**
+     * Get this value as vector<uint8_t>.
+     */
+    std::vector<std::uint8_t> toUint8Array() const;
 
     /**
      * Convert this JsValue to string representation.

--- a/libs/core/include/erdblick/search.h
+++ b/libs/core/include/erdblick/search.h
@@ -35,6 +35,14 @@ public:
      */
     NativeJsValue complete(std::string const& q, int point, NativeJsValue const& options);
 
+    /** Returns a list of diagnostic messages of the following form:
+     *
+     *  [
+     *    {message: string, location: {offset: number, size: numebr}, fix?: string}
+     *  ]
+     */
+    NativeJsValue diagnostics(std::string const& q, NativeJsValue const& diagnostics);
+
 private:
     TileFeatureLayer& tfl_;
 };

--- a/libs/core/src/bindings.cpp
+++ b/libs/core/src/bindings.cpp
@@ -440,7 +440,8 @@ EMSCRIPTEN_BINDINGS(erdblick)
     em::class_<FeatureLayerSearch>("FeatureLayerSearch")
         .constructor<TileFeatureLayer&>()
         .function("filter", &FeatureLayerSearch::filter)
-        .function("complete", &FeatureLayerSearch::complete);
+        .function("complete", &FeatureLayerSearch::complete)
+        .function("diagnostics", &FeatureLayerSearch::diagnostics);
 
     ////////// TileLayerMetadata
     em::value_object<TileLayerParser::TileLayerMetadata>("TileLayerMetadata")

--- a/libs/core/src/cesium-interface/base64.h
+++ b/libs/core/src/cesium-interface/base64.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <cstdint>
+#include <span>
+#include <vector>
+#include <string>
+
+#include "yaml-cpp/binary.h"
+
+namespace erdblick::base64
+{
+
+/**
+ * Encode a vector to a base64 string.
+ *
+ * @param data  Vector to encode
+ */
+inline std::string encode(const std::span<std::uint8_t>& data)
+{
+    return YAML::EncodeBase64(data.data(), data.size());
+}
+
+/**
+ * Decode a base64 encoded vector to an uint8 vector.
+ *
+ * @param data  Base64 string to decode.
+ */
+inline std::vector<std::uint8_t> decode(const std::string& data)
+{
+    return YAML::DecodeBase64(data);
+}
+
+}

--- a/libs/core/src/cesium-interface/object.cpp
+++ b/libs/core/src/cesium-interface/object.cpp
@@ -2,6 +2,8 @@
 
 #if !defined(EMSCRIPTEN)
     #include <stdexcept>
+#else
+    #include "base64.h"
 #endif
 
 

--- a/libs/core/src/cesium-interface/object.cpp
+++ b/libs/core/src/cesium-interface/object.cpp
@@ -2,7 +2,6 @@
 
 #if !defined(EMSCRIPTEN)
     #include <stdexcept>
-#else
     #include "base64.h"
 #endif
 
@@ -183,7 +182,7 @@ std::vector<std::uint8_t> JsValue::toUint8Array() const
                 throw std::range_error("Expected value <= 0xff");
             }
 
-            elements.push_back(static_cast<std::uint8_t>(value));
+            vec.push_back(static_cast<std::uint8_t>(value));
         }
     }
 

--- a/libs/core/src/search.cpp
+++ b/libs/core/src/search.cpp
@@ -190,13 +190,14 @@ erdblick::NativeJsValue erdblick::FeatureLayerSearch::complete(std::string const
     return obj.value_;
 }
 
-erdblick::NativeJsValue erdblick::FeatureLayerSearch::diagnostics(std::string const& q, NativeJsValue const& diagnostics)
+erdblick::NativeJsValue erdblick::FeatureLayerSearch::diagnostics(std::string const& q, NativeJsValue const& ndiagnostics)
 {
+    auto diagnostics = JsValue(ndiagnostics);
     simfil::Diagnostics merged;
 
     const auto length = diagnostics["length"].as<std::size_t>();
     for (auto i = 0; i < length; ++i) {
-        auto buffer = JsValue(diagnostics[i]).toUint8Array();
+        auto buffer = diagnostics.at(i).toUint8Array();
 
         Uint8StreamBuffer streamBuffer(buffer);
         std::istream stream(&streamBuffer);

--- a/libs/core/src/search.cpp
+++ b/libs/core/src/search.cpp
@@ -231,6 +231,7 @@ erdblick::NativeJsValue erdblick::FeatureLayerSearch::diagnostics(std::string co
         });
 
         result.push(JsValue::Dict({
+            {"query", JsValue(q)},
             {"message", JsValue(msg.message)},
             {"location", location},
             {"fix", fixValue},


### PR DESCRIPTION
- Fix a dangling pointer to data in `JsValue::Float64Array`
- Add a new conversion `JsValue::Uint8Array` + `JsValue::toUint8Array`
- Use simfils new diagnostics serialization to share diagnostics objects between workers
- Implement a new Job-Group API to be able to get notified if groups of jobs (e.g. a search) are done, while the job queue still has tasks in it

What changed?
We now schedule the collection of diagnostic messages _after_ a search completed. This is done by using the new JobGroup API, which has a callback that gets triggered if all tasks of the group finished. To not get wrong and/or duplicate messages, we merge all the diagnostics data into one and build the messages.

(Idea: I think we can add some kind of tile sharing between workers by using `SharedArrayBuffer` + locking to reduce parsing the same tile over and over again.)