### PR TITLE
Error: URL too long

### DIFF
--- a/erdblick_app/app/app.component.ts
+++ b/erdblick_app/app/app.component.ts
@@ -6,16 +6,11 @@ import {ParametersService} from "./parameters.service";
 import {filter} from "rxjs";
 import {AppModeService} from "./app-mode.service";
 
-// Centralized helpers for compact URL stringification
-function booleanReplacerForUrl(_: string, value: any) {
-    return typeof value === 'boolean' ? (value ? 1 : 0) : value;
-}
-
+// Helper to stringify with booleans in compact representation
 function stringifyForUrl(value: any): string {
-    if (typeof value === 'boolean') {
-        return value ? '1' : '0';
-    }
-    return JSON.stringify(value, booleanReplacerForUrl);
+    return JSON.stringify(value, (_: string, value: any) => {
+        return typeof value === 'boolean' ? (value ? 1 : 0) : value;
+    });
 }
 
 interface Versions {

--- a/erdblick_app/app/app.component.ts
+++ b/erdblick_app/app/app.component.ts
@@ -6,6 +6,18 @@ import {ParametersService} from "./parameters.service";
 import {filter} from "rxjs";
 import {AppModeService} from "./app-mode.service";
 
+// Centralized helpers for compact URL stringification
+function booleanReplacerForUrl(_: string, value: any) {
+    return typeof value === 'boolean' ? (value ? 1 : 0) : value;
+}
+
+function stringifyForUrl(value: any): string {
+    if (typeof value === 'boolean') {
+        return value ? '1' : '0';
+    }
+    return JSON.stringify(value, booleanReplacerForUrl);
+}
+
 interface Versions {
     name: string;
     tag: string;
@@ -148,7 +160,7 @@ export class AppComponent {
             const entries = [...Object.entries(parameters)].filter(value =>
                 this.parametersService.isUrlParameter(value[0])
             );
-            entries.forEach(entry => entry[1] = JSON.stringify(entry[1]));
+            entries.forEach(entry => entry[1] = stringifyForUrl(entry[1]));
             this.updateQueryParams(Object.fromEntries(entries), this.parametersService.replaceUrl);
         });
     }

--- a/erdblick_app/app/style.service.ts
+++ b/erdblick_app/app/style.service.ts
@@ -111,7 +111,7 @@ export class StyleService {
             console.error(`Error while initializing styles: ${error}`);
         }
         this.loadImportedStyles();
-        this.parameterService.setInitialStyles(Object.fromEntries([...this.styles.entries()].map(([k, v]) => [k, v.params])));
+        this.parameterService.setInitialStyles(this.styles);
     }
 
     async fetchStylesYamlSources(styles: Array<StyleConfigEntry>) {


### PR DESCRIPTION
**Goal**: prevent the URL from getting too long.

**Ticket**: [ERD-213](https://youtrack.nds-association.org/issue/ERD-213/Error-URL-too-long)

**Scope**: 
* AppComponent
* ParameterService

**Deliverables**:
* Filters SourceData and Metadata layers out of the URL string.
* Converts booleans into compact numerical representation (`1` for `true` and `0` for `false`) with backwards compatibility.

**How to test**:
1. Build as usual.
2. Serve.
3. (Optional) Reset the URL parameters in preferences.
4. Inspect the URL.