### PR TITLE
Use first available zoomLevel as default layer level

### DIFF
--- a/app/mapdata/map.tree.model.ts
+++ b/app/mapdata/map.tree.model.ts
@@ -283,10 +283,14 @@ export class MapLayerTree {
         let defaultVisibility = true;
         for (const mapOrGroupItem of this.nodes) {
             for (const featureLayer of mapOrGroupItem.allFeatureLayers()) {
+                const defaultLevel = featureLayer.info.zoomLevels.length
+                    ? featureLayer.info.zoomLevels[0]
+                    : undefined;
                 featureLayer.viewConfig = this.stateService.mapLayerConfig(
                     featureLayer.mapId,
                     featureLayer.info.layerId,
-                    defaultVisibility);
+                    defaultVisibility,
+                    defaultLevel);
                 for (const option of featureLayer.children) {
                     option.value = this.stateService.styleOptionValues(
                         featureLayer.mapId,


### PR DESCRIPTION
Fixes #293

When a layer has `zoomLevels` defined in its LayerInfo, use the first available value as the default instead of the hardcoded 13.