### PR TITLE
Avoid stale datasource catalogs after backend restarts

### DIFF
--- a/app/app.module.ts
+++ b/app/app.module.ts
@@ -2,7 +2,7 @@ import {inject, NgModule, provideAppInitializer} from '@angular/core';
 import {BrowserModule} from '@angular/platform-browser';
 import {AppRoutingModule} from './app.routing.module';
 import {AppComponent} from './app.component';
-import {provideHttpClient} from "@angular/common/http";
+import {provideHttpClient, withFetch} from "@angular/common/http";
 import {DialogModule} from "primeng/dialog";
 import {BrowserAnimationsModule} from "@angular/platform-browser/animations";
 import {AnimateOnScroll} from "primeng/animateonscroll";
@@ -318,7 +318,7 @@ export const initializeServices = () => {
         EditorService,
         RightClickMenuService,
         DialogService,
-        provideHttpClient(),
+        provideHttpClient(withFetch()),
         provideAnimationsAsync(),
         providePrimeNG({
             ripple: true,

--- a/app/mapdata/map-info.service.ts
+++ b/app/mapdata/map-info.service.ts
@@ -149,6 +149,9 @@ export class MapInfoService {
     async reloadDataSources(): Promise<boolean> {
         try {
             const response = await firstValueFrom(this.httpClient.get<Array<MapInfoItem>>("/sources?blocking=false", {
+                // Catalog validators from older mapget servers can collide after a restart.
+                // Fetching the authoritative snapshot must therefore bypass the HTTP cache.
+                cache: "no-store",
                 observe: "response"
             }));
             const result = Array.isArray(response.body) ? response.body : [];

--- a/app/mapdata/map-tile-stream.service.spec.ts
+++ b/app/mapdata/map-tile-stream.service.spec.ts
@@ -1,0 +1,41 @@
+import {Subject} from 'rxjs';
+import {describe, expect, it, vi} from 'vitest';
+import {MapTileStreamService} from './map-tile-stream.service';
+
+describe('MapTileStreamService source catalog refresh', () => {
+    it('reloads again when a backend reconnect races an in-flight catalog fetch', async () => {
+        let finishFirstReload: (() => void) | null = null;
+        const mapInfo = {
+            dataSourceInfoChanged: new Subject<void>(),
+            sourceCatalogRevision: 49,
+            reloadDataSources: vi.fn()
+                .mockImplementationOnce(() => new Promise<boolean>(resolve => {
+                    finishFirstReload = () => resolve(true);
+                }))
+                .mockResolvedValue(true)
+        };
+        const service = new MapTileStreamService(
+            {tilePullCompressionEnabledState: new Subject<boolean>()} as any,
+            mapInfo as any,
+            {viewStateChanged: new Subject<void>()} as any,
+            {} as any,
+            {
+                run: (callback: () => unknown) => callback(),
+                runOutsideAngular: (callback: () => unknown) => callback()
+            } as any
+        );
+        const internals = service as any;
+        internals.tileStream = {getSourcesRevision: () => 1};
+        internals.scheduleUpdate = vi.fn();
+
+        internals.requestSourceCatalogRefresh(49);
+        expect(mapInfo.reloadDataSources).toHaveBeenCalledTimes(1);
+
+        // The new backend may reuse or lower the process-local revision while
+        // the request started against its predecessor is still unresolved.
+        internals.handleSourcesRevisionChanged(1, true);
+        finishFirstReload?.();
+
+        await vi.waitFor(() => expect(mapInfo.reloadDataSources).toHaveBeenCalledTimes(2));
+    });
+});

--- a/app/mapdata/map-tile-stream.service.spec.ts
+++ b/app/mapdata/map-tile-stream.service.spec.ts
@@ -4,14 +4,15 @@ import {MapTileStreamService} from './map-tile-stream.service';
 
 describe('MapTileStreamService source catalog refresh', () => {
     it('reloads again when a backend reconnect races an in-flight catalog fetch', async () => {
-        let finishFirstReload: (() => void) | null = null;
+        let finishFirstReload!: () => void;
+        const firstReload = new Promise<boolean>(resolve => {
+            finishFirstReload = () => resolve(true);
+        });
         const mapInfo = {
             dataSourceInfoChanged: new Subject<void>(),
             sourceCatalogRevision: 49,
             reloadDataSources: vi.fn()
-                .mockImplementationOnce(() => new Promise<boolean>(resolve => {
-                    finishFirstReload = () => resolve(true);
-                }))
+                .mockReturnValueOnce(firstReload)
                 .mockResolvedValue(true)
         };
         const service = new MapTileStreamService(
@@ -34,7 +35,7 @@ describe('MapTileStreamService source catalog refresh', () => {
         // The new backend may reuse or lower the process-local revision while
         // the request started against its predecessor is still unresolved.
         internals.handleSourcesRevisionChanged(1, true);
-        finishFirstReload?.();
+        finishFirstReload();
 
         await vi.waitFor(() => expect(mapInfo.reloadDataSources).toHaveBeenCalledTimes(2));
     });

--- a/app/mapdata/map-tile-stream.service.ts
+++ b/app/mapdata/map-tile-stream.service.ts
@@ -122,6 +122,8 @@ export class MapTileStreamService {
     private readonly searchResultEntryFrameBudgetMs = 12;
     private sourceCatalogReloadPromise: Promise<void> | null = null;
     private sourceCatalogRefreshTargetRevision: number | null = null;
+    /** Guarantees an authoritative refresh after an older connection's in-flight reload completes. */
+    private sourceCatalogReloadAfterCurrent: boolean = false;
     private backendProtocolMismatchActive = false;
 
     constructor(
@@ -160,8 +162,8 @@ export class MapTileStreamService {
         this.tileStream.onSourceCatalogChanged = (change) => {
             this.ngZone.runOutsideAngular(() => this.handleSourceCatalogChanged(change));
         };
-        this.tileStream.onSourcesRevisionChanged = (revision) => {
-            this.ngZone.runOutsideAngular(() => this.handleSourcesRevisionChanged(revision));
+        this.tileStream.onSourcesRevisionChanged = (revision, reconnected) => {
+            this.ngZone.runOutsideAngular(() => this.handleSourcesRevisionChanged(revision, reconnected));
         };
         this.tileStream.onOpen = () => {
             this.ngZone.run(() => {
@@ -509,23 +511,30 @@ export class MapTileStreamService {
     }
 
     /** Refreshes `/sources` when request-context frames prove our catalog snapshot is stale. */
-    private handleSourcesRevisionChanged(revision: number): void {
+    private handleSourcesRevisionChanged(revision: number, reconnected: boolean): void {
         const currentRevision = this.mapInfo.sourceCatalogRevision;
-        if (currentRevision !== null && currentRevision >= revision) {
+        if (!reconnected && currentRevision !== null && currentRevision >= revision) {
             return;
         }
-        this.requestSourceCatalogRefresh(revision);
+        // Catalog revisions are process-local. The first context frame after a
+        // reconnect must discard targets from the previous backend incarnation.
+        this.requestSourceCatalogRefresh(revision, reconnected);
     }
 
-    /** Coalesces heavyweight `/sources` refreshes and retries once when the first snapshot was too early. */
-    private requestSourceCatalogRefresh(targetRevision: number | null = null): void {
+    /** Coalesces `/sources` refreshes while keeping revision targets scoped to one backend connection. */
+    private requestSourceCatalogRefresh(targetRevision: number | null = null, resetRevisionEpoch: boolean = false): void {
         if (targetRevision !== null && Number.isFinite(targetRevision)) {
             const normalizedRevision = Math.max(0, Math.floor(targetRevision));
-            this.sourceCatalogRefreshTargetRevision = this.sourceCatalogRefreshTargetRevision === null
+            this.sourceCatalogRefreshTargetRevision = resetRevisionEpoch || this.sourceCatalogRefreshTargetRevision === null
                 ? normalizedRevision
                 : Math.max(this.sourceCatalogRefreshTargetRevision, normalizedRevision);
+        } else if (resetRevisionEpoch) {
+            this.sourceCatalogRefreshTargetRevision = null;
         }
         if (this.sourceCatalogReloadPromise) {
+            // The running fetch may belong to the previous backend process. A
+            // second fetch is required even if its response happens to look current.
+            this.sourceCatalogReloadAfterCurrent ||= resetRevisionEpoch;
             return;
         }
         this.sourceCatalogReloadPromise = this.reloadSourceCatalogUntilCaughtUp()
@@ -533,6 +542,12 @@ export class MapTileStreamService {
             .catch(err => console.error("Failed to refresh datasource catalog.", err))
             .finally(() => {
                 this.sourceCatalogReloadPromise = null;
+                if (this.sourceCatalogReloadAfterCurrent) {
+                    this.sourceCatalogReloadAfterCurrent = false;
+                    this.sourceCatalogRefreshTargetRevision = null;
+                    this.requestSourceCatalogRefresh();
+                    return;
+                }
                 const pendingRevision = this.sourceCatalogRefreshTargetRevision;
                 if (pendingRevision !== null) {
                     const currentRevision = this.mapInfo.sourceCatalogRevision;

--- a/app/mapdata/tilestream.spec.ts
+++ b/app/mapdata/tilestream.spec.ts
@@ -170,6 +170,39 @@ describe('MapTileStreamClient', () => {
         }
     });
 
+    it('reports a repeated revision after reconnecting to a restarted backend', async () => {
+        const client = new MapTileStreamClient('/interactive');
+        const tileStream = client as any;
+        const observedRevisions: Array<{revision: number; reconnected: boolean}> = [];
+        try {
+            client.withSourcesRevisionChangedCallback((revision, reconnected) => {
+                observedRevisions.push({revision, reconnected});
+            });
+
+            tileStream.prepareForOpenedSocket();
+            await tileStream.handleFrame(jsonFrame(MAP_TILE_STREAM_TYPE_REQUEST_CONTEXT, {
+                type: 'mapget.tiles.request-context',
+                requestId: 3,
+                sourcesRevision: 49
+            }), MAP_TILE_STREAM_TYPE_REQUEST_CONTEXT);
+
+            tileStream.prepareForOpenedSocket();
+            expect(client.getSourcesRevision()).toBeNull();
+            await tileStream.handleFrame(jsonFrame(MAP_TILE_STREAM_TYPE_REQUEST_CONTEXT, {
+                type: 'mapget.tiles.request-context',
+                requestId: 4,
+                sourcesRevision: 49
+            }), MAP_TILE_STREAM_TYPE_REQUEST_CONTEXT);
+
+            expect(observedRevisions).toEqual([
+                {revision: 49, reconnected: false},
+                {revision: 49, reconnected: true}
+            ]);
+        } finally {
+            client.destroy();
+        }
+    });
+
     it('rejects stale payload frames after datasource metadata changes', async () => {
         const client = new MapTileStreamClient('/interactive');
         const tileStream = client as any;

--- a/app/mapdata/tilestream.ts
+++ b/app/mapdata/tilestream.ts
@@ -196,6 +196,10 @@ export class MapTileStreamClient {
     private usingLegacyPullFallback: boolean = false;
     private readonly ownsParser: boolean;
     private protocolMismatchReported: boolean = false;
+    /** Counts successful websocket connections so the first context frame can identify reconnects. */
+    private openedSocketCount: number = 0;
+    /** True until the current socket identifies its datasource-catalog revision. */
+    private awaitingSocketSourcesRevision: boolean = false;
 
     onFrame: ((frame: Uint8Array, type: number) => void) | null = null;
     onFeatures: ((payload: Uint8Array) => void) | null = null;
@@ -205,7 +209,7 @@ export class MapTileStreamClient {
     onStatus: ((status: MapTileStreamStatusPayload) => void) | null = null;
     onSearchStatus: ((status: MapTileStreamSearchStatusPayload) => void) | null = null;
     onSourceCatalogChanged: ((change: MapTileStreamSourceCatalogChangePayload) => void) | null = null;
-    onSourcesRevisionChanged: ((revision: number) => void) | null = null;
+    onSourcesRevisionChanged: ((revision: number, reconnected: boolean) => void) | null = null;
     onOpen: (() => void) | null = null;
     onError: ((event: Event) => void) | null = null;
     onClose: ((event: CloseEvent) => void) | null = null;
@@ -260,8 +264,8 @@ export class MapTileStreamClient {
         return this;
     }
 
-    /** Registers the callback that receives datasource-catalog revision updates from request-context frames. */
-    withSourcesRevisionChangedCallback(callback: (revision: number) => void) {
+    /** Registers revision updates and identifies the first context received after a websocket reconnect. */
+    withSourcesRevisionChangedCallback(callback: (revision: number, reconnected: boolean) => void) {
         this.onSourcesRevisionChanged = callback;
         return this;
     }
@@ -355,6 +359,8 @@ export class MapTileStreamClient {
         this.supportsRequestContextFrames = false;
         this.pullClientId = null;
         this.sourcesRevision = null;
+        this.openedSocketCount = 0;
+        this.awaitingSocketSourcesRevision = false;
         this.stopPullLoops();
         this.clearPendingFrames();
         this.resetCompletionPromise();
@@ -418,15 +424,24 @@ export class MapTileStreamClient {
     }
 
     /** Stores the newest datasource-catalog revision and optionally notifies consumers. */
-    private updateSourcesRevision(revision: number, notify: boolean): void {
+    private updateSourcesRevision(revision: number, notify: boolean, reconnected: boolean = false): void {
         const nextRevision = Math.max(0, Math.floor(revision));
         const previousRevision = this.sourcesRevision;
         this.sourcesRevision = previousRevision === null
             ? nextRevision
             : Math.max(previousRevision, nextRevision);
-        if (notify && (previousRevision === null || nextRevision > previousRevision)) {
-            this.onSourcesRevisionChanged?.(nextRevision);
+        if (notify && (reconnected || previousRevision === null || nextRevision > previousRevision)) {
+            this.onSourcesRevisionChanged?.(nextRevision, reconnected);
         }
+    }
+
+    /** Starts a new connection-scoped revision sequence and records whether this is a reconnect. */
+    private prepareForOpenedSocket(): void {
+        this.openedSocketCount++;
+        this.awaitingSocketSourcesRevision = true;
+        // Revisions are process-local; retaining the previous socket's maximum
+        // would hide equal or lower revisions after a backend restart.
+        this.sourcesRevision = null;
     }
 
     /** Returns aggregated compression metrics for `/interactive/payload` responses. */
@@ -722,6 +737,7 @@ export class MapTileStreamClient {
                     return;
                 }
                 opened = true;
+                this.prepareForOpenedSocket();
                 this.protocolMismatchReported = false;
                 this.onOpen?.();
                 resolve();
@@ -1010,7 +1026,10 @@ export class MapTileStreamClient {
                         this.supportsRequestContextFrames = true;
                         this.incomingRequestId = Math.max(0, Math.floor(payload.requestId));
                         if (Number.isFinite(payload.sourcesRevision)) {
-                            this.updateSourcesRevision(Number(payload.sourcesRevision), true);
+                            const reconnected = this.awaitingSocketSourcesRevision
+                                && this.openedSocketCount > 1;
+                            this.awaitingSocketSourcesRevision = false;
+                            this.updateSourcesRevision(Number(payload.sourcesRevision), true, reconnected);
                         }
                         if (Number.isFinite(payload.clientId)) {
                             const nextClientId = Math.max(1, Math.floor(Number(payload.clientId)));


### PR DESCRIPTION
## Summary
- fetch `/sources?blocking=false` through Angular's Fetch backend with `cache: "no-store"`
- treat each WebSocket connection as a new datasource-revision epoch, so repeated or lower revisions after a backend restart trigger a refresh
- guarantee a follow-up catalog fetch when a reconnect races an in-flight fetch from the previous backend process
- cover repeated revisions and the in-flight reconnect race with focused tests

## Root cause
mapget datasource revisions and the corresponding ETags are process-local. A restarted backend can therefore reuse an earlier revision while returning different datasource metadata. Browser caching and erdblick's previous globally-monotonic revision handling could preserve a stale `/sources` response across that restart.

## Impact
Erdblick now obtains an authoritative datasource catalog after backend reconnects and cannot suppress the refresh merely because the new process reports an equal or lower revision.

## Validation
- `npm run test -- --watch=false` — 27 test files and 304 tests passed
- focused ESLint checks passed
- `npx tsc --noEmit -p tsconfig.app.json` passed
- `npm run build` passed with the existing bundle-budget warning
- GitHub Actions: release build, native tests, Angular/Vitest tests, and Playwright integration tests all passed